### PR TITLE
Update behat test.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -113,7 +113,7 @@
   <!-- Installs govCMS and sets it up for development. -->
   <target name="site:install" depends="env">
     <!-- Use passthru() when executing drush site-install so that we'll know if errors occur. -->
-    <exec command="${drush} site-install govcms --yes --site-name=govCMS8 --account-pass=admin --db-url=${db.url}" dir="${docroot}" passthru="true"/>
+    <exec command="${drush} site-install govcms --yes --site-name=GovCMS --account-pass=admin --db-url=${db.url}" dir="${docroot}" passthru="true"/>
     <chmod file="${site}" mode="0755"/>
   </target>
 

--- a/tests/behat/features/ui/home.feature
+++ b/tests/behat/features/ui/home.feature
@@ -2,13 +2,12 @@ Feature: Home Page
   Ensure the home page is rendering correctly
 
   Background:
-    [Given|*] I am on the homepage
+    Given I am an anonymous user
+    When I visit "/"
 
   @api @javascript
   Scenario: View the homepage content
-    Given I am an anonymous user
     Then I should see "Welcome to govCMS8"
 
   Scenario: Check the homepage meta tag.
-    Given I am an anonymous user
     Then the response should contain "<meta name=\"Generator\" content=\"Drupal 8 (http://drupal.org) + govCMS (http://govcms.gov.au)\" />"

--- a/tests/behat/features/ui/home.feature
+++ b/tests/behat/features/ui/home.feature
@@ -7,7 +7,7 @@ Feature: Home Page
 
   @api @javascript
   Scenario: View the homepage content
-    Then I should see "Welcome to govCMS8"
+    Then I should see "Welcome to GovCMS"
 
   Scenario: Check the homepage meta tag.
     Then the response should contain "<meta name=\"Generator\" content=\"Drupal 8 (http://drupal.org) + govCMS (http://govcms.gov.au)\" />"


### PR DESCRIPTION
Hopefully I have finally figured out what was wrong with the failing Behat test in Travis.

### Issue descritption

If you install the site without default content module (as Travis is doing) there is no content at all, no homepage etc. And in that case the behat test for **[Given|*] I am on the homepage** is redirecting to /user/logout for some reason. 

### Solution

I've changed **[Given|*] I am on the homepage** to **When I visit "/"** which will end on the "front page" regardles if there is any content or not.