### PR TITLE
Remove rollback

### DIFF
--- a/modules/custom/optional/govcms8_default_content/README.md
+++ b/modules/custom/optional/govcms8_default_content/README.md
@@ -10,7 +10,7 @@ It also create a test which can be used to showcase all the different paragraph 
 
 The content will be imported when the module is  **installed**.
 
-If you **uninstall** the module the content will be deleted (rolled back).
+If you **uninstall** the module the content will stay.
 
 Two Drush commands were created to import and rollback content:
 

--- a/modules/custom/optional/govcms8_default_content/govcms8_default_content.install
+++ b/modules/custom/optional/govcms8_default_content/govcms8_default_content.install
@@ -27,11 +27,3 @@ function govcms8_default_content_install() {
   }
 }
 
-/**
- * Implements hook_uninstall().
- */
-function govcms8_default_content_uninstall() {
-  if (!\Drupal::service('config.installer')->isSyncing()) {
-    \Drupal::classResolver()->getInstanceFromDefinition(InstallHelper::class)->deleteImportedContent();
-  }
-}


### PR DESCRIPTION
To prevent confussion of users we should not delete the imported content if the default content module is un-installed.

Removing the imported content may be usefull when debugging the imported content, so the drush commands stay intact.