### PR TITLE
Add missing media image view modes.

### DIFF
--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.featured.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.featured.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.featured
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - image.style.featured
+    - media.type.image
+  module:
+    - field_layout
+    - image
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
+id: media.image.featured
+targetEntityType: media
+bundle: image
+mode: featured
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: featured
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  field_tags: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.landscape.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.landscape.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.landscape
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - image.style.landscape
+    - media.type.image
+  module:
+    - field_layout
+    - image
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
+id: media.image.landscape
+targetEntityType: media
+bundle: image
+mode: landscape
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: landscape
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  field_tags: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.square.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.square.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.square
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - image.style.square
+    - media.type.image
+  module:
+    - field_layout
+    - image
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
+id: media.image.square
+targetEntityType: media
+bundle: image
+mode: square
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: square
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  field_tags: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_mode.media.featured.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_mode.media.featured.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.featured
+label: Featured
+targetEntityType: media
+cache: true

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_mode.media.landscape.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_mode.media.landscape.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.landscape
+label: Landscape
+targetEntityType: media
+cache: true

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_mode.media.square.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_mode.media.square.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.square
+label: Square
+targetEntityType: media
+cache: true


### PR DESCRIPTION
Content types view modes are set to use specific view modes for rendering image media entities. e.g. "Square", but these view modes are missing on the Image media entity.