### PR TITLE
[GCMSLG-102] Change Node / Other Lists to list markup.

### DIFF
--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/views.view.govcms_blog_article_views.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/views.view.govcms_blog_article_views.yml
@@ -67,7 +67,14 @@ display:
             previous: ‹‹
             next: ››
       style:
-        type: default
+        type: html_list
+        options:
+          row_class: views-row
+          default_row_class: true
+          uses_fields: false
+          type: ul
+          wrapper_class: views-list
+          class: ''
       row:
         type: 'entity:node'
         options:

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/views.view.govcms_views_searchapi_events.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/views.view.govcms_views_searchapi_events.yml
@@ -66,7 +66,14 @@ display:
             offset: false
             offset_label: Offset
       style:
-        type: default
+        type: html_list
+        options:
+          row_class: views-row
+          default_row_class: true
+          uses_fields: false
+          type: ul
+          wrapper_class: views-list
+          class: ''
       row:
         type: search_api
         options:

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/views.view.govcms_foi_views.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/views.view.govcms_foi_views.yml
@@ -67,7 +67,14 @@ display:
             previous: ‹‹
             next: ››
       style:
-        type: default
+        type: html_list
+        options:
+          row_class: views-row
+          default_row_class: true
+          uses_fields: false
+          type: ul
+          wrapper_class: views-list
+          class: ''
       row:
         type: 'entity:node'
         options:

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/views.view.govcms_news_and_media.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/views.view.govcms_news_and_media.yml
@@ -254,11 +254,14 @@ display:
             offset_label: Offset
           quantity: 9
       style:
-        type: default
+        type: html_list
         options:
           row_class: views-row
           default_row_class: false
           uses_fields: false
+          type: ul
+          wrapper_class: views-list
+          class: ''
       row:
         type: 'entity:node'
         options:


### PR DESCRIPTION
Change markup of Events, FOI, Blog and News & Media lists to use HTML list instead of div to follow the example of Design System's Card list component (https://designsystem.gov.au/components/cards/). 

Card list component is currently under development so this PR just updates the markup to use HTML list and ensures the style remains the same. Further changes would be required once the component is officially released. 

Related CSS change in govcms8_uikit_starter theme: https://github.com/govCMS/govcms8_uikit_starter/pull/41