### PR TITLE
[GCMSLG-112] Remove secondary inner main element from /page_layouts

### DIFF
--- a/modules/custom/core/govcms8_foundations/modules/govcms8_layouts/templates/page_layouts/govcms_page.html.twig
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_layouts/templates/page_layouts/govcms_page.html.twig
@@ -33,9 +33,9 @@
       {% endif %}
       {% if content.content|render|striptags|trim or content.sidebar|render|striptags|trim %}
         <div class="row">
-          <main class="page-layout__content">
+          <div class="page-layout__content">
             {{ content.content }}
-          </main>
+          </div>
           <aside class="page-layout__sidebar">
             {{ content.sidebar }}
           </aside>

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_layouts/templates/page_layouts/page_edgy.html.twig
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_layouts/templates/page_layouts/page_edgy.html.twig
@@ -24,9 +24,9 @@
       {% endif %}
       {% if content.content|render|striptags|trim %}
         <div class="row">
-          <main class="page-layout__content">
+          <div class="page-layout__content">
             {{ content.content }}
-          </main>
+          </div>
         </div>
       {% endif %}
       {% if content.content_bottom|render|striptags|trim %}


### PR DESCRIPTION
Justification for inner main removal:

> A hierarchically correct main element is one whose ancestor elements are limited to html, body, div, form without an accessible name, and autonomous custom elements. Each main element must be a hierarchically correct main element.
http://w3c.github.io/html/grouping-content.html#elementdef-main

* As the inner main (or nested main) lives within a <section> element, it seems to violate the ancestor limitations listed above.
* General examples on the [WC3 main|http://w3c.github.io/html/grouping-content.html#elementdef-main] show the main element living closer to the root. The inner main was rather nested and excluded wrapping content like breadcrumbs / H1 heading and article footer elements.
* By removing the outer main, the page.html.twig structure would need to change to ensure a main existed for non-panelizer pages - this makes the change a bit more complicated without solving the above 2 issues.