### PR TITLE
Use Travis to test off-version PHP builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ cache:
     - "$HOME/.npm"
 
 php:
-  - 7.1
   - 7.2
+  - 7.3
 
 matrix:
   allow_failures:
-  - php:          7.2
+  - php:          7.3
   fast_finish:    true
 
 before_install:


### PR DESCRIPTION
Travis currently tests builds on PHP 7.1 and PHP 7.2
CircleCI also tests the current GovCMS version of PHP (currently 7.1).
We should use TravisCI to test the PHP versions we aren't already testing (7.2 and 7.3 currently).
As and when we move to 7.2, we can change this to 7.1 & 7.3.