### PR TITLE
Update Drupal core to 8.6.6

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "^8.6.2",
+        "drupal/core": "8.6.6",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/consumers": "1.2.0",
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
-        "drupal/core": "8.6.4",
+        "drupal/core": "8.6.6",
         "drupal/dropzonejs": "2.0.0-alpha3",
         "drupal/ds": "3.1",
         "drupal/entity_browser": "2.0",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,4 +1,4 @@
 core = 8.x
 api = 2
 projects[drupal][type] = core
-projects[drupal][version] = 8.6.4
+projects[drupal][version] = 8.6.6


### PR DESCRIPTION
Security updates released this morning.

See https://www.drupal.org/project/drupal/releases/8.6.6 for more information including links to security advisory notices.
