### PR TITLE
Update solr dataDir path and disable locking.

### DIFF
--- a/.docker/Dockerfile.solr
+++ b/.docker/Dockerfile.solr
@@ -3,3 +3,11 @@ FROM ${CLI_IMAGE} as cli
 
 FROM amazeeio/solr:6.6-drupal
 COPY --from=cli /app/web/modules/contrib/search_api_solr/solr-conf/6.x/ /solr-conf/conf/
+
+USER root
+RUN sed -i -e "s#<dataDir>\${solr.data.dir:}#<dataDir>/var/solr/\${solr.core.name}#g" /solr-conf/conf/solrconfig.xml \
+    && sed -i -e "s#solr.lock.type:native#solr.lock.type:none#g" /solr-conf/conf/solrconfig.xml
+
+USER solr
+RUN precreate-core drupal /solr-conf
+CMD ["solr-foreground"]


### PR DESCRIPTION
As per GovCMS7 PR: https://github.com/govCMS/govCMS/pull/773

Upstream changes require the default `dataDir` of solr to be updated to `/var/solr/${solr.core.name}`.

Also includes change to disable locking which fixes issues where the Solr didn't fully bootstrap after the container was stopped non-gracefully.

https://github.com/amazeeio/lagoon/releases/tag/v0.19.1