### PR TITLE
reference govcms/govcms: "*" to build local instead of download packagist version

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -27,7 +27,7 @@
         "drupal/console": "^1.0.2",
         "drupal/core": "8.6.7",
         "drush/drush": "^9.0.0",
-        "govcms/govcms": "1.0.0-beta1",
+        "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3"
     },


### PR DESCRIPTION
With the `"govcms/govcms": "1.0.0-beta1",` set, Composer will download that specified version from Packagist - this will not allow for local modifications to the distro, and will result in mismatches, especially for core releases.

Setting `"govcms/govcms": "*",` will force composer to mirror the install from /src - allowing for local modifications ahead of the previous version to be admitted.

` - Installing govcms/govcms (dev-master): Mirroring from /src`