### PR TITLE
Update Drupal Core to 8.6.9

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -27,7 +27,7 @@
         "drupal/console": "^1.0.2",
         "drupal/core": "8.6.9",
         "drush/drush": "^9.0.0",
-        "govcms/govcms": "1.0.0-beta1",
+        "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3"
     },

--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "8.6.7",
+        "drupal/core": "8.6.9",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "1.0.0-beta1",
         "webflo/drupal-finder": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/consumers": "1.4",
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
-        "drupal/core": "8.6.7",
+        "drupal/core": "8.6.9",
         "drupal/dropzonejs": "2.0.0-alpha3",
         "drupal/ds": "3.2",
         "drupal/entity_browser": "2.0",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,4 +1,4 @@
 core = 8.x
 api = 2
 projects[drupal][type] = core
-projects[drupal][version] = 8.6.7
+projects[drupal][version] = 8.6.9


### PR DESCRIPTION
## https://www.drupal.org/project/drupal/releases/8.6.9

Release notes
This is a patch release of Drupal 8 and is ready for use on production sites. Learn more about Drupal 8.

If you are upgrading to this release from 8.5.x, read the Drupal 8.6.0 release notes before upgrading to 8.6.9.

Changes since 8.6.8:

#2215857 followup by gaydamaka, timmillwood, alexpott, lauriii: Regression on Internet Explorer 11
#3031128 by alexpott, TrevorBradley, indigoxela, catch, cilefen, larowlan, jibran: Update from 8.6.7 to 8.6.8 warnings - Drupal\Core\Extension\Extension has no unserializer
Revert "Issue #2924201 by tim.plunkett, tedbow, larowlan, xjm, jibran, Kristen Pol: Resolve random failure in LayoutBuilderTest so that it can be added to HEAD"
#2924201 by tim.plunkett, tedbow, larowlan, xjm, jibran, Kristen Pol: Resolve random failure in LayoutBuilderTest so that it can be added to HEAD
Known issues
#2215857: Behaviors get attached to removed forms
#3031128: Update from 8.6.7 to 8.6.8 warnings - Drupal\Core\Extension\Extension has no unserializer
#3026560: After upgrade to 7.63, 8.6.7, or 8.5.10 still get TYPO3 phar error for drush
#3026443: \Drupal\Core\Security\PharExtensionInterceptor is incompatible with GeoIP and other libraries that use phar aliases or Phar::mapPhar()
Drupal 8.6.9 has been released to resolve some of these issues.

## https://www.drupal.org/project/drupal/releases/8.6.8

Changes since 8.6.7
#2975539 by mondrake, alexpott, marcoscano, desierto: Changing machine name of image style leads to WSOD when loading widgets that used the old name
#2859315 by quietone, heddn, jhodgdon: SQL error from profile_fields when migrating d6 (or d7) to d8 without Profile module
#2443165 by davidwbarratt, amateescu, HOG, kostyashupenko, yched, Berdir, andypost, alexpott, tstoeckler, xjm: Drupal\Core\Entity\EntityInterface\ContentEntityStorageBase::doCreate() assumes that the bundle is a string
#2849074 by decafdennis, alexpott, zuuperman, AdamPS, sagesolutions, tucho, xjm: SiteConfigureForm overrides value from install profile
#3007716 by Sam152, kevin.dutra, jhedstrom, larowlan: Security update introduces breaking changes to content moderation
#2215857 by michielnugter, Lendude, gmercer, tim.plunkett, cferthorney, marabak, olli, ericmulder1980, TwoD, sanduhrs, stella, dww, nod_: Behaviors get attached to removed forms
#3017812 by ibustos, joachim: Language selector is immune to hook_entity_field_access in entity forms
#2900883 by larskhansen, GaëlG, kalyansamanta, Chi, tim.plunkett, Gábor Hojtsy, joachim: Wrong documentation of Drupal\Component\Plugin\Derivative\DeriverInterface::getDerivativeDefinitions()
#3027595 by amateescu, pmelab: Incorrect blacklist condition in WorkspaceManager
#2725259 by sardara, andrewmacpherson, claudiu.cristea, tedbow, alwaysworking, droplet, techmsi, kwoxer, xjm, alexpott, lauriii, catch, cilefen, Cottser: [regression] Table Drag handles no longer respond to up/down arrow keys
Revert "Issue #2725259 by sardara, andrewmacpherson, claudiu.cristea, tedbow, alwaysworking, droplet, techmsi, kwoxer, xjm, alexpott, @catch, @cilefen, @Cottser, @lauriii: [regression] Table Drag handles no longer respond to up/down arrow keys"
#2725259 by sardara, andrewmacpherson, claudiu.cristea, tedbow, alwaysworking, droplet, techmsi, kwoxer, xjm, alexpott, @catch, @cilefen, @Cottser, @lauriii: [regression] Table Drag handles no longer respond to up/down arrow keys
#2937073 by tim.plunkett, Saviktor, tedbow: Improve robustness of FieldBlockTest
#2973713 by quietone, Adita, etecjdo, apmsooner, mikeryan, gnuschichten, tstoeckler: cache_key source plugin configuration not documented
#2949555 by quietone, ankitjain28may: Correct the documentation on method UserMigrationClassTest
#3025685 by quietone: Add error msg to assertions in MigrateSourceTestBase
#3026840 by izus: Fix plural typo in workspaces field
#3024452 by kfritsche, hchonov, alexpott: DatabaseStorageExpirable:setWithExpireIfNotExists is not respecting expired
#2999908 by penyaskito: View more link in recipe cards is not fully translated
#3028819 by alwaysworking: Update username
#2916021 by d.olaresko, wengerk, Chi, xjm, dawehner, idebr: Update "Running tests" section in core.api.php
#2953995 by kjay, starshaped, rachel_norfolk, Vidushi Mehta, cferthorney, HAL 9000, Eli-T, markconroy, steveparks: Update the Umami Vegan Chocolate Brownie recipe
#3028608 by danharper, Eli-T, markconroy, Not Real: Umami - favicon
#2940027 by jmsosso: Add change record to @deprecated for AccountInterface
#2995150 by msankhala, tim.plunkett: Command examples in core/tests/README.md are confusing and not executable
#3024184 by seanB, andrewmacpherson, Kristen Pol: Make the tabbing order match the visual reading order in MediaLibraryWidget
#2668416 by Krzysztof Domański, wheatpenny, Lendude, alexpott: Wrong assert in NodeTitleTest
#2981870 by Lendude, alexpott: Duplicate BrokenSetUpTest for BrowserTestBase
#2809513 by Lendude, brentgees: Convert AJAX part of \Drupal\responsive_image\Tests\ResponsiveImageFieldUiTest to JavascriptTestBase and the rest to BrowserTestBase
#3027574 by tuutti: SqlContentEntityStorage no longer update entities with certain (id) fields
#3026043 by Berdir: ConfigEntityBase::__sleep() serializes plugin instances if they were not previously initialized
#3021395 by quietone, alexpott: MigrateDrupalTestBase::migrateContent(['translations') does not migrate translations
Revert "Issue #3003238 by Sam152, amateescu, Berdir: EntityStorageException: Default revision can not be deleted in content_moderation_entity_revision_delete()"
#2987418 by quietone, Kristen Pol: Rename MigrateUpgrade tests
#3003238 by Sam152, amateescu, Berdir: EntityStorageException: Default revision can not be deleted in content_moderation_entity_revision_delete()
#3026470 by alexpott, jrockowitz, Joseph Zhao: ArchiveTar is throwing fatal error
Merged 8.6.7.
Merged 8.6.6.
#3015992 by Krzysztof Domański, alexpott, larowlan: Not affecting spacing in PhpTransliterationTest
#2998769 by kiamlaluno, quietone, kkalaskar: @see directive used in the wrong place outputs the wrong HTML markup
#3000677 by catch, Shane Birley, featherbelly, alexpott, larowlan: Fatal error after upgrade to 8.6x [due to regression in extension system]
#2955457 by pfrenssen, Chewie, unrealauk, alexpott, Pol: ConfigFactory static cache gets polluted with data from config overrides
#3020142 by mglaman, tim.plunkett: Test module no_transitions_css has invalid hook_page_attachments
#3007973 by tim.plunkett, lukasss, xopoc, bnjmnm, stompersly: Layout builder prevents the rendering of extra fields (like Links) on pages not using Layout Builder
#3024259 by Pol, alexpott: [PHP 7.3] Fix EnvironmentTest::providerTestCheckMemoryLimit() notice
#3023747 by mikelutz, heddn: D6 profile migrations assume stubs, which fail
#2978922 by brathbone, philipnorton42, msankhala, hardikpandya, alexpott, siliconmeadow: Improve batch_process() documentation
#2845975 by quietone, Jo Fitzgerald, aleevas, maxocub, Gábor Hojtsy: Migrate Drupal 6 user profile field value option translations
#2701829 by alexpott, andypost, Soul88, Graber, Eduardo Morales, dawehner, pingwin4eg, catch, Berdir, jibran, httang12: Extension objects should not implement \Serializable
#2693727 by mikelutz, sanduhrs, CalebD, ajlib, Lendude, tstoeckler, catch: Limiting options for exposed Language filters causes errors and doesn't work for special languages