### PR TITLE
Update Drupal core to 8.6.10 (Critical Release - PSA-2019-02-19)

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -27,7 +27,7 @@
         "drupal/console": "^1.0.2",
         "drupal/core": "8.6.7",
         "drush/drush": "^9.0.0",
-        "govcms/govcms": "*",
+        "govcms/govcms": "1.0.0-beta2",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3"
     },

--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "8.6.7",
+        "drupal/core": "8.6.10",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "1.0.0-beta2",
         "webflo/drupal-finder": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/consumers": "1.4",
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
-        "drupal/core": "8.6.7",
+        "drupal/core": "8.6.10",
         "drupal/dropzonejs": "2.0.0-alpha3",
         "drupal/ds": "3.2",
         "drupal/entity_browser": "2.0",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,4 +1,4 @@
 core = 8.x
 api = 2
 projects[drupal][type] = core
-projects[drupal][version] = 8.6.7
+projects[drupal][version] = 8.6.10


### PR DESCRIPTION
This is placeholder PR for the coming Drupal 8 core security release.

https://www.drupal.org/psa-2019-02-19

