### PR TITLE
Added exclude for node_modules folder inside the custom themes.

### DIFF
--- a/.docker/scripts/lint-theme
+++ b/.docker/scripts/lint-theme
@@ -5,7 +5,7 @@ APP_DIR=${APP_DIR:-/app}
 PROFILE_DIR=${PROFILE_DIR:-${APP_DIR}/web}
 
 # Lint code.
-${APP_DIR}/tests/vendor/bin/parallel-lint --exclude /app/tests/vendor -e php,inc,module,theme,install,profile,test ${PROFILE_DIR}/themes/custom
+${APP_DIR}/tests/vendor/bin/parallel-lint --exclude /app/tests/vendor --exclude ${PROFILE_DIR}/themes/custom/*/node_modules -e php,inc,module,theme,install,profile,test ${PROFILE_DIR}/themes/custom
 
 # Check code standards.
 ${APP_DIR}/tests/vendor/bin/phpcs --standard=${APP_DIR}/tests/phpcs.xml ${PROFILE_DIR}/themes/custom


### PR DESCRIPTION
Without this line, node_modules directory gets linted and produced large number of warnings.