### PR TITLE
Pin ctools to 3.0.0 version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
         "drupal/core": "8.6.10",
+        "drupal/ctools": "3.0.0",
         "drupal/dropzonejs": "2.0.0-alpha3",
         "drupal/ds": "3.2",
         "drupal/entity_browser": "2.0",


### PR DESCRIPTION
We currently don't include ctools in the composer.json (but we do in the d.o. make file)

Setting the composer.json version to 3.0.0 to match makefile.

Not updating to 3.2.0 until https://www.drupal.org/project/panels/issues/3031778 is resolved with a new Panels release (#236 currently blocked)

Ref: GOVCMSD8-293