### PR TITLE
Add webflo/drupal-core-strict to match drupal/core version

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -29,7 +29,8 @@
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",
-        "webmozart/path-util": "^2.3"
+        "webmozart/path-util": "^2.3",
+        "webflo/drupal-core-strict": "8.6.10"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
This PR uses webflo/drupal-core-strict to effectively pin all non-composer requirements to those matching each drupal/core release.

This will minimise the impact of components that update midway through a drupal release cycle from causing us undue headaches.