### PR TITLE
Update Drupal/core to 8.6.12 and add drupal-core-strict

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,11 +25,12 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "8.6.10",
+        "drupal/core": "8.6.12",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",
-        "webmozart/path-util": "^2.3"
+        "webmozart/path-util": "^2.3",
+        "webflo/drupal-core-strict": "8.6.12"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
-        "drupal/core": "8.6.10",
+        "drupal/core": "8.6.12",
         "drupal/ctools": "3.0.0",
         "drupal/dropzonejs": "2.0.0-alpha3",
         "drupal/ds": "3.2",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,4 +1,4 @@
 core = 8.x
 api = 2
 projects[drupal][type] = core
-projects[drupal][version] = 8.6.10
+projects[drupal][version] = 8.6.12


### PR DESCRIPTION
supercedes https://github.com/govCMS/govCMS8/pull/250 

This PR uses webflo/drupal-core-strict to match drupal/core version to effectively pin all non specified drupal requirements to those matching each drupal/core release.

This will minimise the impact of components that update midway through a drupal release cycle from causing us undue headaches.