### PR TITLE
Enabled Environment Indicator module.

### DIFF
--- a/config/install/environment_indicator.settings.yml
+++ b/config/install/environment_indicator.settings.yml
@@ -1,0 +1,3 @@
+toolbar_integration:
+  - toolbar
+favicon: true

--- a/govcms.info.yml
+++ b/govcms.info.yml
@@ -56,6 +56,7 @@ dependencies:
   - events_log_track:event_log_track_media
   - events_log_track:event_log_track_user
   - events_log_track:event_log_track_workflows
+  - environment_indicator:environment_indicator
   - features_ui
   - field_group
   - focal_point


### PR DESCRIPTION
This PR is to enable the Environment Indicator by default. The actual settings are configured in the govCMS8 Docker image from the PR: https://github.com/govCMS/govcms8lagoon/pull/40