### PR TITLE
[GOVCMSD8-381] Remove field_layout experimental core module from distribution

### DIFF
--- a/govcms.info.yml
+++ b/govcms.info.yml
@@ -18,7 +18,6 @@ dependencies:
   - config
   - content_moderation
   - datetime_range
-  - field_layout
   - field_ui
   - help
   - history

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.accordion.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.accordion.default.yml
@@ -10,13 +10,8 @@ dependencies:
     - field.field.paragraph.accordion.field_title
     - paragraphs.paragraphs_type.accordion
   module:
-    - field_layout
     - layout_discovery
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.accordion.default
 targetEntityType: paragraph
 bundle: accordion

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.accordion_group.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.accordion_group.default.yml
@@ -15,14 +15,9 @@ dependencies:
     - paragraphs.paragraphs_type.accordion_group
   module:
     - content_moderation
-    - field_layout
     - layout_discovery
     - paragraphs
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.accordion_group.default
 targetEntityType: paragraph
 bundle: accordion_group

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.content.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.content.default.yml
@@ -13,15 +13,10 @@ dependencies:
     - paragraphs.paragraphs_type.content
   module:
     - content_moderation
-    - field_layout
     - layout_discovery
     - link
     - paragraphs
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.content.default
 targetEntityType: paragraph
 bundle: content

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.item.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.item.default.yml
@@ -11,14 +11,9 @@ dependencies:
     - field.field.paragraph.item.field_title
     - paragraphs.paragraphs_type.item
   module:
-    - field_layout
     - layout_discovery
     - link
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.item.default
 targetEntityType: paragraph
 bundle: item

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.item_list.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.item_list.default.yml
@@ -15,15 +15,10 @@ dependencies:
     - field.field.paragraph.item_list.field_title
     - paragraphs.paragraphs_type.item_list
   module:
-    - field_layout
     - layout_discovery
     - link
     - paragraphs
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.item_list.default
 targetEntityType: paragraph
 bundle: item_list

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.node_list.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_form_display.paragraph.node_list.default.yml
@@ -15,15 +15,10 @@ dependencies:
     - field.field.paragraph.node_list.field_title
     - paragraphs.paragraphs_type.node_list
   module:
-    - field_layout
     - layout_discovery
     - link
     - paragraphs
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.node_list.default
 targetEntityType: paragraph
 bundle: node_list

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.content.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.content.default.yml
@@ -13,13 +13,8 @@ dependencies:
     - paragraphs.paragraphs_type.content
   module:
     - entity_class_formatter
-    - field_layout
     - link
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.content.default
 targetEntityType: paragraph
 bundle: content

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.content.preview.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.content.preview.yml
@@ -9,12 +9,7 @@ dependencies:
     - field.field.paragraph.content.field_title
     - paragraphs.paragraphs_type.content
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.content.preview
 targetEntityType: paragraph
 bundle: content

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.default.yml
@@ -11,13 +11,8 @@ dependencies:
     - field.field.paragraph.item.field_title
     - paragraphs.paragraphs_type.item
   module:
-    - field_layout
     - link
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.item.default
 targetEntityType: paragraph
 bundle: item

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.preview.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.preview.yml
@@ -11,11 +11,6 @@ dependencies:
     - field.field.paragraph.item.field_title
     - paragraphs.paragraphs_type.item
   module:
-    - field_layout
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.item.preview
 targetEntityType: paragraph
 bundle: item

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.search.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.search.yml
@@ -12,12 +12,8 @@ dependencies:
     - paragraphs.paragraphs_type.item
   module:
     - ds
-    - field_layout
     - text
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: search

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.stack_detail.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.stack_detail.yml
@@ -13,13 +13,9 @@ dependencies:
     - paragraphs.paragraphs_type.item
   module:
     - ds
-    - field_layout
     - linked_field
     - text
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: stack_detail

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.stack_simple.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.stack_simple.yml
@@ -13,12 +13,8 @@ dependencies:
     - paragraphs.paragraphs_type.item
   module:
     - ds
-    - field_layout
     - linked_field
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: stack_simple

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.summary.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.summary.yml
@@ -12,12 +12,8 @@ dependencies:
     - paragraphs.paragraphs_type.item
   module:
     - ds
-    - field_layout
     - text
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: summary

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.teaser.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.teaser.yml
@@ -13,13 +13,9 @@ dependencies:
     - paragraphs.paragraphs_type.item
   module:
     - ds
-    - field_layout
     - linked_field
     - text
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: teaser

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.teaser_small.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item.teaser_small.yml
@@ -13,13 +13,9 @@ dependencies:
     - paragraphs.paragraphs_type.item
   module:
     - ds
-    - field_layout
     - linked_field
     - text
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: teaser_small

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item_list.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item_list.default.yml
@@ -18,13 +18,8 @@ dependencies:
     - ds
     - entity_class_formatter
     - entity_reference_display
-    - field_layout
     - link
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.item_list.default
 targetEntityType: paragraph
 bundle: item_list

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item_list.preview.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.item_list.preview.yml
@@ -9,12 +9,7 @@ dependencies:
     - field.field.paragraph.item_list.field_title
     - paragraphs.paragraphs_type.item_list
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.item_list.preview
 targetEntityType: paragraph
 bundle: item_list

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.node_list.default.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.node_list.default.yml
@@ -17,13 +17,8 @@ dependencies:
   module:
     - entity_class_formatter
     - entity_reference_display
-    - field_layout
     - link
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.node_list.default
 targetEntityType: paragraph
 bundle: node_list

--- a/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.node_list.preview.yml
+++ b/modules/custom/core/govcms8_foundations/config/install/core.entity_view_display.paragraph.node_list.preview.yml
@@ -9,12 +9,7 @@ dependencies:
     - field.field.paragraph.node_list.field_title
     - paragraphs.paragraphs_type.node_list
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.node_list.preview
 targetEntityType: paragraph
 bundle: node_list

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.color_background_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.color_background_modifier.default.yml
@@ -9,12 +9,7 @@ dependencies:
     - field.field.paragraph.color_background_modifier.field_mod_transition_duration
     - paragraphs.paragraphs_type.color_background_modifier
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.color_background_modifier.default
 targetEntityType: paragraph
 bundle: color_background_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.custom_linear_gradient_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.custom_linear_gradient_modifier.default.yml
@@ -8,12 +8,7 @@ dependencies:
     - field.field.paragraph.custom_linear_gradient_modifier.field_mod_media_query
     - paragraphs.paragraphs_type.custom_linear_gradient_modifier
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.custom_linear_gradient_modifier.default
 targetEntityType: paragraph
 bundle: custom_linear_gradient_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.image_bg_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.image_bg_modifier.default.yml
@@ -13,12 +13,7 @@ dependencies:
   module:
     - content_moderation
     - entity_browser
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.image_bg_modifier.default
 targetEntityType: paragraph
 bundle: image_bg_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.padding_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.padding_modifier.default.yml
@@ -13,10 +13,6 @@ dependencies:
     - field.field.paragraph.padding_modifier.field_mod_padding_t_size
     - field.field.paragraph.padding_modifier.field_mod_padding_t_units
     - paragraphs.paragraphs_type.padding_modifier
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.padding_modifier.default
 targetEntityType: paragraph
 bundle: padding_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.parallax_bg_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.parallax_bg_modifier.default.yml
@@ -12,12 +12,7 @@ dependencies:
   module:
     - content_moderation
     - entity_browser
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.parallax_bg_modifier.default
 targetEntityType: paragraph
 bundle: parallax_bg_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.relative_height_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_form_display.paragraph.relative_height_modifier.default.yml
@@ -7,10 +7,6 @@ dependencies:
     - field.field.paragraph.relative_height_modifier.field_mod_relative_height
     - field.field.paragraph.relative_height_modifier.field_mod_vertical_align
     - paragraphs.paragraphs_type.relative_height_modifier
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 _core:
   default_config_hash: h9mnkhKukCT7CN6MeOhNL-gfR9N-k2RGyWHjHdN_FkY
 id: paragraph.relative_height_modifier.default

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.image_bg_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.image_bg_modifier.default.yml
@@ -11,14 +11,9 @@ dependencies:
     - image.style.thumbnail
     - paragraphs.paragraphs_type.image_bg_modifier
   module:
-    - field_layout
     - layout_discovery
     - media
     - options
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.image_bg_modifier.default
 targetEntityType: paragraph
 bundle: image_bg_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.image_bg_modifier.preview.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.image_bg_modifier.preview.yml
@@ -11,12 +11,7 @@ dependencies:
     - field.field.paragraph.image_bg_modifier.field_mod_media_query
     - paragraphs.paragraphs_type.image_bg_modifier
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.image_bg_modifier.preview
 targetEntityType: paragraph
 bundle: image_bg_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.padding_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.padding_modifier.default.yml
@@ -14,13 +14,8 @@ dependencies:
     - field.field.paragraph.padding_modifier.field_mod_padding_t_units
     - paragraphs.paragraphs_type.padding_modifier
   module:
-    - field_layout
     - layout_discovery
     - options
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.padding_modifier.default
 targetEntityType: paragraph
 bundle: padding_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.padding_modifier.preview.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.padding_modifier.preview.yml
@@ -15,12 +15,7 @@ dependencies:
     - field.field.paragraph.padding_modifier.field_mod_padding_t_units
     - paragraphs.paragraphs_type.padding_modifier
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.padding_modifier.preview
 targetEntityType: paragraph
 bundle: padding_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.parallax_bg_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.parallax_bg_modifier.default.yml
@@ -9,12 +9,7 @@ dependencies:
     - field.field.paragraph.parallax_bg_modifier.field_mod_parallax_speed
     - paragraphs.paragraphs_type.parallax_bg_modifier
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.parallax_bg_modifier.default
 targetEntityType: paragraph
 bundle: parallax_bg_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.parallax_bg_modifier.preview.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.parallax_bg_modifier.preview.yml
@@ -10,12 +10,7 @@ dependencies:
     - field.field.paragraph.parallax_bg_modifier.field_mod_parallax_speed
     - paragraphs.paragraphs_type.parallax_bg_modifier
   module:
-    - field_layout
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: paragraph.parallax_bg_modifier.preview
 targetEntityType: paragraph
 bundle: parallax_bg_modifier

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.relative_height_modifier.default.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.relative_height_modifier.default.yml
@@ -8,13 +8,8 @@ dependencies:
     - field.field.paragraph.relative_height_modifier.field_mod_vertical_align
     - paragraphs.paragraphs_type.relative_height_modifier
   module:
-    - field_layout
     - layout_discovery
     - options
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 _core:
   default_config_hash: nANjU2eWnkY1SRh2QvwMwQPwjOkh4lNg6v-Dq3fuAsU
 id: paragraph.relative_height_modifier.default

--- a/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.relative_height_modifier.preview.yml
+++ b/modules/custom/core/govcms8_foundations/modules/govcms8_modifiers/config/install/core.entity_view_display.paragraph.relative_height_modifier.preview.yml
@@ -9,13 +9,8 @@ dependencies:
     - field.field.paragraph.relative_height_modifier.field_mod_vertical_align
     - paragraphs.paragraphs_type.relative_height_modifier
   module:
-    - field_layout
     - layout_discovery
     - options
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 _core:
   default_config_hash: nANjU2eWnkY1SRh2QvwMwQPwjOkh4lNg6v-Dq3fuAsU
 id: paragraph.relative_height_modifier.preview

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_form_display.node.govcms_blog_article.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_form_display.node.govcms_blog_article.default.yml
@@ -14,17 +14,12 @@ dependencies:
   module:
     - content_moderation
     - entity_browser
-    - field_layout
     - file
     - layout_discovery
     - panelizer
     - paragraphs
     - path
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: node.govcms_blog_article.default
 targetEntityType: node
 bundle: govcms_blog_article

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.calendar_item.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.calendar_item.yml
@@ -13,14 +13,10 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.default.yml
@@ -12,15 +12,11 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - entity_reference_revisions
-    - field_layout
     - file
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.full.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.full.yml
@@ -12,15 +12,11 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - entity_reference_revisions
-    - field_layout
     - file
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: true
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.search.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.search.yml
@@ -13,14 +13,10 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.stack_detail.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.stack_detail.yml
@@ -13,15 +13,11 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.stack_simple.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.stack_simple.yml
@@ -13,14 +13,10 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.summary.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.summary.yml
@@ -13,14 +13,10 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.teaser.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.teaser.yml
@@ -13,15 +13,11 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.teaser_small.yml
+++ b/modules/custom/core/govcms_content_types/govcms_blog_article/config/install/core.entity_view_display.node.govcms_blog_article.teaser_small.yml
@@ -13,15 +13,11 @@ dependencies:
     - node.type.govcms_blog_article
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_content_types.info.yml
+++ b/modules/custom/core/govcms_content_types/govcms_content_types.info.yml
@@ -6,7 +6,6 @@ dependencies:
   - content_moderation
   - entity_browser
   - field
-  - field_layout
   - file
   - govcms_media
   - govcms8_foundations

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_form_display.node.govcms_event.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_form_display.node.govcms_event.default.yml
@@ -17,17 +17,12 @@ dependencies:
     - content_moderation
     - entity_browser
     - datetime_range
-    - field_layout
     - file
     - layout_discovery
     - panelizer
     - paragraphs
     - path
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: node.govcms_event.default
 targetEntityType: node
 bundle: govcms_event

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.calendar_item.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.calendar_item.yml
@@ -15,15 +15,11 @@ dependencies:
     - node.type.govcms_event
   module:
     - ds
-    - field_layout
     - govcms8_calendar_item
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.default.yml
@@ -15,15 +15,11 @@ dependencies:
   module:
     - datetime_range
     - entity_reference_revisions
-    - field_layout
     - file
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.full.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.full.yml
@@ -15,15 +15,11 @@ dependencies:
   module:
     - datetime_range
     - entity_reference_revisions
-    - field_layout
     - file
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: true
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.search.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.search.yml
@@ -16,14 +16,10 @@ dependencies:
   module:
     - datetime_range
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.stack_detail.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.stack_detail.yml
@@ -16,15 +16,11 @@ dependencies:
   module:
     - datetime_range
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.stack_simple.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.stack_simple.yml
@@ -16,14 +16,10 @@ dependencies:
   module:
     - datetime_range
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.summary.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.summary.yml
@@ -16,14 +16,10 @@ dependencies:
   module:
     - datetime_range
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.teaser.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.teaser.yml
@@ -16,15 +16,11 @@ dependencies:
   module:
     - datetime_range
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.teaser_small.yml
+++ b/modules/custom/core/govcms_content_types/govcms_event/config/install/core.entity_view_display.node.govcms_event.teaser_small.yml
@@ -16,15 +16,11 @@ dependencies:
   module:
     - datetime_range
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_form_display.node.govcms_foi.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_form_display.node.govcms_foi.default.yml
@@ -17,17 +17,12 @@ dependencies:
     - content_moderation
     - entity_browser
     - datetime
-    - field_layout
     - file
     - layout_discovery
     - panelizer
     - paragraphs
     - path
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: node.govcms_foi.default
 targetEntityType: node
 bundle: govcms_foi

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.calendar_item.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.calendar_item.yml
@@ -15,15 +15,11 @@ dependencies:
     - node.type.govcms_foi
   module:
     - ds
-    - field_layout
     - govcms8_calendar_item
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.default.yml
@@ -15,15 +15,11 @@ dependencies:
   module:
     - datetime
     - entity_reference_revisions
-    - field_layout
     - file
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.full.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.full.yml
@@ -15,15 +15,11 @@ dependencies:
   module:
     - datetime
     - entity_reference_revisions
-    - field_layout
     - file
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: true
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.search.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.search.yml
@@ -16,14 +16,10 @@ dependencies:
   module:
     - datetime
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.stack_detail.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.stack_detail.yml
@@ -16,15 +16,11 @@ dependencies:
   module:
     - datetime
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.stack_simple.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.stack_simple.yml
@@ -16,14 +16,10 @@ dependencies:
   module:
     - datetime
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.summary.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.summary.yml
@@ -16,14 +16,10 @@ dependencies:
   module:
     - datetime
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.teaser.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.teaser.yml
@@ -16,15 +16,11 @@ dependencies:
   module:
     - datetime
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.teaser_small.yml
+++ b/modules/custom/core/govcms_content_types/govcms_foi/config/install/core.entity_view_display.node.govcms_foi.teaser_small.yml
@@ -16,15 +16,11 @@ dependencies:
   module:
     - datetime
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_form_display.node.govcms_news_and_media.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_form_display.node.govcms_news_and_media.default.yml
@@ -15,17 +15,12 @@ dependencies:
   module:
     - content_moderation
     - entity_browser
-    - field_layout
     - file
     - layout_discovery
     - panelizer
     - paragraphs
     - path
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: node.govcms_news_and_media.default
 targetEntityType: node
 bundle: govcms_news_and_media

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.calendar_item.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.calendar_item.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.govcms_news_and_media
   module:
     - ds
-    - field_layout
     - panelizer
     - text
     - user
@@ -24,9 +23,6 @@ third_party_settings:
     custom: false
     allow: false
     default: default
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: calendar_item

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.default.yml
@@ -13,7 +13,6 @@ dependencies:
     - node.type.govcms_news_and_media
   module:
     - entity_reference_revisions
-    - field_layout
     - file
     - options
     - panelizer
@@ -25,9 +24,6 @@ third_party_settings:
     custom: false
     allow: false
     default: default
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: node.govcms_news_and_media.default
 targetEntityType: node
 bundle: govcms_news_and_media

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.full.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.full.yml
@@ -12,16 +12,12 @@ dependencies:
     - field.field.node.govcms_news_and_media.panelizer
     - node.type.govcms_news_and_media
   module:
-    - field_layout
     - file
     - options
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: true
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.search.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.search.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.govcms_news_and_media
   module:
     - ds
-    - field_layout
     - options
     - panelizer
     - text
@@ -25,9 +24,6 @@ third_party_settings:
     custom: false
     allow: false
     default: default
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: search

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.stack_detail.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.stack_detail.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.govcms_news_and_media
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
@@ -25,9 +24,6 @@ third_party_settings:
     custom: false
     allow: false
     default: default
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: stack_detail

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.stack_simple.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.stack_simple.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.govcms_news_and_media
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - user
@@ -24,9 +23,6 @@ third_party_settings:
     custom: false
     allow: false
     default: default
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: stack_simple

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.summary.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.summary.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.govcms_news_and_media
   module:
     - ds
-    - field_layout
     - panelizer
     - text
     - user
@@ -24,9 +23,6 @@ third_party_settings:
     custom: false
     allow: false
     default: default
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: summary

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.teaser.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.teaser.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.govcms_news_and_media
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
@@ -25,9 +24,6 @@ third_party_settings:
     custom: false
     allow: false
     default: default
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: teaser

--- a/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.teaser_small.yml
+++ b/modules/custom/core/govcms_content_types/govcms_news_and_media/config/install/core.entity_view_display.node.govcms_news_and_media.teaser_small.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.govcms_news_and_media
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
@@ -25,9 +24,6 @@ third_party_settings:
     custom: false
     allow: false
     default: default
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   ds:
     layout:
       id: teaser_small

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_form_display.node.govcms_standard_page.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_form_display.node.govcms_standard_page.default.yml
@@ -13,17 +13,12 @@ dependencies:
   module:
     - content_moderation
     - entity_browser
-    - field_layout
     - file
     - layout_discovery
     - panelizer
     - paragraphs
     - path
     - text
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: node.govcms_standard_page.default
 targetEntityType: node
 bundle: govcms_standard_page

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.calendar_item.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.calendar_item.yml
@@ -11,14 +11,10 @@ dependencies:
     - node.type.govcms_standard_page
   module:
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.default.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.default.yml
@@ -11,15 +11,11 @@ dependencies:
     - node.type.govcms_standard_page
   module:
     - entity_reference_revisions
-    - field_layout
     - file
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.full.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.full.yml
@@ -10,15 +10,11 @@ dependencies:
     - field.field.node.govcms_standard_page.panelizer
     - node.type.govcms_standard_page
   module:
-    - field_layout
     - file
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: true
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.search.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.search.yml
@@ -12,14 +12,10 @@ dependencies:
     - node.type.govcms_standard_page
   module:
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.stack_detail.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.stack_detail.yml
@@ -12,15 +12,11 @@ dependencies:
     - node.type.govcms_standard_page
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.stack_simple.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.stack_simple.yml
@@ -12,14 +12,10 @@ dependencies:
     - node.type.govcms_standard_page
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.summary.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.summary.yml
@@ -11,14 +11,10 @@ dependencies:
     - node.type.govcms_standard_page
   module:
     - ds
-    - field_layout
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.teaser.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.teaser.yml
@@ -12,15 +12,11 @@ dependencies:
     - node.type.govcms_standard_page
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.teaser_small.yml
+++ b/modules/custom/core/govcms_content_types/govcms_standard_page/config/install/core.entity_view_display.node.govcms_standard_page.teaser_small.yml
@@ -12,15 +12,11 @@ dependencies:
     - node.type.govcms_standard_page
   module:
     - ds
-    - field_layout
     - linked_field
     - panelizer
     - text
     - user
 third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
   panelizer:
     enable: false
     custom: false

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.audio.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.audio.default.yml
@@ -6,13 +6,8 @@ dependencies:
     - field.field.media.audio.field_tags
     - media.type.audio
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.audio.default
 targetEntityType: media
 bundle: audio

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.audio.summary.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.audio.summary.yml
@@ -7,13 +7,8 @@ dependencies:
     - field.field.media.audio.field_tags
     - media.type.audio
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.audio.summary
 targetEntityType: media
 bundle: audio

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.file.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.file.default.yml
@@ -6,13 +6,8 @@ dependencies:
     - field.field.media.file.field_tags
     - media.type.file
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.file.default
 targetEntityType: media
 bundle: file

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.file.summary.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.file.summary.yml
@@ -7,13 +7,8 @@ dependencies:
     - field.field.media.file.field_tags
     - media.type.file
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.file.summary
 targetEntityType: media
 bundle: file

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.image.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.image.default.yml
@@ -7,13 +7,8 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
-    - field_layout
     - image
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.image.default
 targetEntityType: media
 bundle: image

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.image.summary.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.image.summary.yml
@@ -8,13 +8,8 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
-    - field_layout
     - image
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.image.summary
 targetEntityType: media
 bundle: image

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.remote_video.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.remote_video.default.yml
@@ -6,13 +6,8 @@ dependencies:
     - field.field.media.remote_video.field_tags
     - media.type.remote_video
   module:
-    - field_layout
     - layout_discovery
     - media
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.remote_video.default
 targetEntityType: media
 bundle: remote_video

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.remote_video.summary.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.remote_video.summary.yml
@@ -7,13 +7,8 @@ dependencies:
     - field.field.media.remote_video.field_tags
     - media.type.remote_video
   module:
-    - field_layout
     - layout_discovery
     - media
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.remote_video.summary
 targetEntityType: media
 bundle: remote_video

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.video.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.video.default.yml
@@ -6,13 +6,8 @@ dependencies:
     - field.field.media.video.field_tags
     - media.type.video
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.video.default
 targetEntityType: media
 bundle: video

--- a/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.video.summary.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_form_display.media.video.summary.yml
@@ -7,13 +7,8 @@ dependencies:
     - field.field.media.video.field_tags
     - media.type.video
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.video.summary
 targetEntityType: media
 bundle: video

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.audio.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.audio.default.yml
@@ -6,13 +6,8 @@ dependencies:
     - field.field.media.audio.field_tags
     - media.type.audio
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.audio.default
 targetEntityType: media
 bundle: audio

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.audio.thumbnail.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.audio.thumbnail.yml
@@ -7,13 +7,8 @@ dependencies:
     - image.style.thumbnail
     - media.type.audio
   module:
-    - field_layout
     - image
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.audio.thumbnail
 targetEntityType: media
 bundle: audio

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.file.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.file.default.yml
@@ -6,13 +6,8 @@ dependencies:
     - field.field.media.file.field_tags
     - media.type.file
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.file.default
 targetEntityType: media
 bundle: file

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.file.thumbnail.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.file.thumbnail.yml
@@ -7,13 +7,8 @@ dependencies:
     - image.style.thumbnail
     - media.type.file
   module:
-    - field_layout
     - image
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.file.thumbnail
 targetEntityType: media
 bundle: file

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.default.yml
@@ -6,13 +6,8 @@ dependencies:
     - field.field.media.image.field_tags
     - media.type.image
   module:
-    - field_layout
     - image
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.image.default
 targetEntityType: media
 bundle: image

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.featured.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.featured.yml
@@ -8,12 +8,7 @@ dependencies:
     - image.style.featured
     - media.type.image
   module:
-    - field_layout
     - image
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.image.featured
 targetEntityType: media
 bundle: image

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.landscape.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.landscape.yml
@@ -8,12 +8,7 @@ dependencies:
     - image.style.landscape
     - media.type.image
   module:
-    - field_layout
     - image
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.image.landscape
 targetEntityType: media
 bundle: image

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.square.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.square.yml
@@ -8,12 +8,7 @@ dependencies:
     - image.style.square
     - media.type.image
   module:
-    - field_layout
     - image
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.image.square
 targetEntityType: media
 bundle: image

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.thumbnail.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.image.thumbnail.yml
@@ -8,13 +8,8 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
-    - field_layout
     - image
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.image.thumbnail
 targetEntityType: media
 bundle: image

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.remote_video.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.remote_video.default.yml
@@ -6,12 +6,7 @@ dependencies:
     - field.field.media.remote_video.field_tags
     - media.type.remote_video
   module:
-    - field_layout
     - media
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.remote_video.default
 targetEntityType: media
 bundle: remote_video

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.video.default.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.video.default.yml
@@ -6,13 +6,8 @@ dependencies:
     - field.field.media.video.field_tags
     - media.type.video
   module:
-    - field_layout
     - file
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.video.default
 targetEntityType: media
 bundle: video

--- a/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.video.thumbnail.yml
+++ b/modules/custom/core/govcms_media/config/install/core.entity_view_display.media.video.thumbnail.yml
@@ -7,13 +7,8 @@ dependencies:
     - image.style.thumbnail
     - media.type.video
   module:
-    - field_layout
     - image
     - layout_discovery
-third_party_settings:
-  field_layout:
-    id: layout_onecol
-    settings: {  }
 id: media.video.thumbnail
 targetEntityType: media
 bundle: video

--- a/modules/custom/core/govcms_media/govcms_media.info.yml
+++ b/modules/custom/core/govcms_media/govcms_media.info.yml
@@ -10,7 +10,6 @@ dependencies:
   - entity_browser
   - entity_embed
   - field
-  - field_layout
   - file
   - focal_point
   - image


### PR DESCRIPTION
Thanks to @simesy for pointing out https://www.drupal.org/project/drupal/issues/3007167

With field_layout being removed from D8, we need to ensure that any of our config that depends on it can be cleaned up.

An initial review has shown that we were only ever using default settings in config - and this _should_ be able to be safely removed ahead of time.