### PR TITLE
[GOVCMSD8-418] Update Drupal core to 8.7.6

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,12 +25,12 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "8.7.5",
+        "drupal/core": "8.7.6",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "webflo/drupal-core-strict": "8.7.5"
+        "webflo/drupal-core-strict": "8.7.6"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,12 +25,12 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "8.7.3",
+        "drupal/core": "8.7.5",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "webflo/drupal-core-strict": "8.7.3"
+        "webflo/drupal-core-strict": "8.7.5"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
-        "drupal/core": "8.7.3",
+        "drupal/core": "8.7.5",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0-rc2",
         "drupal/devel": "2.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
-        "drupal/core": "8.7.5",
+        "drupal/core": "8.7.6",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0-rc2",
         "drupal/devel": "2.0",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,4 +1,4 @@
 core = 8.x
 api = 2
 projects[drupal][type] = core
-projects[drupal][version] = 8.7.5
+projects[drupal][version] = 8.7.6

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,4 +1,4 @@
 core = 8.x
 api = 2
 projects[drupal][type] = core
-projects[drupal][version] = 8.7.3
+projects[drupal][version] = 8.7.5


### PR DESCRIPTION
## Drupal 8.7.6 Release notes
This is a **patch release of Drupal 8** and is ready for use on production sites. Learn more about Drupal 8.

If you are upgrading to this release from 8.6.x, read the Drupal 8.7.0 release notes before upgrading to this release.

Drupal 8.7.x will receive security coverage until June 3rd 2020 when Drupal 8.9.x is released.

**All changes since Drupal 8.7.4**

- #2825516 by mikelutz, amwhalen, jhedstrom, pwolanin, ragnarkurm: hook_node_access() is called with $op = 'delete' when the create node form is shown

- #3029627 by bobbygryzynger, tim.plunkett, xjm, johndevman: FormatterBase should pass along third party settings
- #2973137 by davps, efpapado, tstoeckler: EntityViewsData missed revisionable validation
- #3067041 by seanB, dhirendra.mishra, Al Munnings, handspiker, phenaproxima, DannyBoing: Media library pagination is broken due to invalid entity_id parameter
- #3070604 by christinlepson, joachim, jhodgdon: badly named and documented parameter for FormBuilder::buildForm()
- #3070880 by bkosborne: One of methods documented by Drupal core to create a CKEditor build does not work anymore: update docs
- #3066439 follow-up by alexpott: Stop invoking pre-save methods in EntityStorageInterface::restore()
- #3068661 by bomoko, idebr: Docblock for "neutral" method in AccessResult.php is incorrect
- #3066439 by alexpott, amateescu, Charlie ChX Negyesi, catch, casey, Berdir, daniel.bosen: Stop invoking pre-save methods in EntityStorageInterface::restore()
- #2780475 by alexpott, Jo Fitzgerald, mpdonadio, dawehner: assertEscaped() and assertUnescaped don't work as you would expect in JavascriptTestBase
- #3060550 by Firass Ziedan: oembed link does not pass the URL parameter to the provider
- #1476782 by daffie, droplet, donquixote, Katiemouse, Lendude, lnunesbr, ekl1773, init90, jhedstrom, catch, clemens.tolboom, amateescu: DatabaseStatementPrefetch::current PHP function array_unshift() are used incorrectly
SA-CORE-2019-008 by dwbotsch, xjm, mlhess, cilefen, greggles, drumm, alexpott, amateescu
- #3065212 by amateescu, pmelab, leolando.tan: Workspaces views query alter multiplies result set by number of languages
- #3063020 by mpp: Support translation of the list of styles in CKEditor
- #2863986 by bircher, alexpott, pfrenssen, claudiu.cristea, Adita, dawehner, gambry, chr.fritsch, catch: Allow updating modules with new service dependencies
- #3065663 by phenaproxima, amateescu, alexpott, tim.plunkett, Wim Leers: Several post-update functions try to update config entity types without checking if they exist
- #3062157 by swetha kashetty, shubham.prakash, andrewmacpherson: Document summary_attributes variable in details.html.twig
- #3065586 by Charlie ChX Negyesi, alexpott: ConditionManager::execute() implementation doesn't conform to the interface
- #2996431 by andypost, Charlie ChX Negyesi, Xano: Fix docs for ConditionPluginBase
- #3050757 by Wim Leers: Update CKEditor to 4.11.4

## Drupal 8.7.5 Release notes

Maintenance and security release of the Drupal 8 series.

This release fixes security vulnerabilities. Sites are urged to upgrade immediately after reading the notes below and the security announcement:

> Drupal core - Access bypass - SA-CORE-2019-008

No other fixes are included.
Which release do I choose? Security coverage information

> Drupal 8.7.x will receive security coverage until June 3, 2020 when Drupal 8.9.0 is released.
> Sites on 8.6.x or earlier do not require an update for this release.
> Versions of Drupal 8 prior to 8.6.x are end-of-life and do not receive security coverage.

### Important update information

>For sites with the Workspaces module enabled, update.php needs to run to ensure a required cache clear. If there is a reverse proxy cache or content delivery network (e.g. Varnish, CloudFlare) it is also advisable to clear these as well.

>No changes have been made to the .htaccess, web.config, robots.txt, or default settings.php files in this release, so upgrading custom versions of those files is not necessary if your site is already on the previous release.



## Drupal 8.7.4 Release notes

This is a patch release of Drupal 8 and is ready for use on production sites. Learn more about Drupal 8.

If you are upgrading to this release from 8.6.x, read the Drupal 8.7.0 release notes before upgrading to this release.

Drupal 8.7.x will receive security coverage until June 3rd 2020 when Drupal 8.9.x is released.

### Changes since 8.7.3:

* #3038254 by phenaproxima, seanB, Wim Leers, yogeshmpawar, effulgentsia, alexpott, larowlan: Delegate media library access to the "thing" that opened the library
* #3042223 follow-up by alexpott: Map text_plain field formatter to string
* Revert "Issue #3054649 by Mile23, alexpott: DrupalKernelTest results in ERROR HANDLER CHANGED!"
* #3035408 by seanB, andrewmacpherson, phenaproxima, mgifford, rainbreaw: Identify purpose of vertical tabs in MediaLibraryWidget dialog for assistive tech users
* #3055760 by huzooka, thangaraj.moorthi, John Cook: Fix RTL styles of Vertical tabs in Seven theme
* #3054649 by Mile23, alexpott: DrupalKernelTest results in ERROR HANDLER CHANGED!
* #2829990 by Krzysztof Domański, idebr, lamp5: Image formatter does not support URL/Link options
* #3056454 by Krzysztof Domański, John Cook, johndevman: Hexadecimal validation returns true if the color contains multiple hashes (e.g. '###FF0')
* #3059022 by alexpott, bnjmnm, dww, phenaproxima, seanB, Krzysztof Domański: If Vimeo is down our tests break
* #2979044 by BR0kEN, alexpott: Unable to change menu items weight when the "system.site.weight_select_max" exceeded and "#pre_render" for "number" element is modified
* #3054582 by jeqq, blazey, Leksat, Gábor Hojtsy, larowlan, amateescu: Add field ui to workspaces
* #3042223 by juampynr, heddn: Map text_plain field formatter to string
* #3045384 by mxr576, yogeshmpawar, amateescu: Fix incorrect assumption that all entity are revisionable
* #3060081 by pfrenssen, borisson_: Recalculation of display cacheability metadata during module install causing error
* #3049895 by quietone: Move setupMigrations to Credential form and remove duplicate code
* #3062556 by alexpott, catch, phenaproxima, larowlan: UpdatePathTestBase does not support the $configSchemaCheckerExclusions property
* #3061564 by cyb.tachyon: Fix null type hint on \Drupal::getContainer()
* #3050577 by fconnolly, mgifford: Remove hidden site name link in menu
* #2944552 by mpdonadio, bhanuprakashnani, liquidcms, Sophie.SK, tacituseu: Documentation for #default_value in Date form element is incorrect
* #3056414 by yogeshmpawar, R.shaikh, joachim, John Cook: inaccurate property docs for Drupal\Core\Site\Settings
* #3060603 by nuez, marcoscano, phenaproxima, alexpott, seanB: Live preview is broken when editing the media_library view
* #3044649 by phenaproxima, seanB, Wim Leers, alexpott: Delegate media library selection handling to the "thing" that opened the library
* Revert "Issue #2979966 by quietone, PieterDC, masipila, heddn, Gábor Hojtsy: Migrate D7 i18n taxonomy term language"
* #3027598 by amateescu, pmelab, alexpott, larowlan: Omit workspaces entity presave and predelete hooks for internal entities
* #3021247 by jeqq, alexpott, amateescu: Bypass workspace access permission is not working as expected
* #2991577 by BrightBold, cristiroma, lolcode, morrisona, cosmicdreams, Eli-T, alexpott, jcloys, pawandubey, shaal, kjay: Pluralise taxonomy terms in Umami's Recipe Category vocabulary
* #3060983 by alexpott, Eli-T: Upgrade chokidar so that we can install on OSX with the latest stable node/npm/yarn binaries
* #3039730 by ndobromirov, Wim Leers, e0ipso, l0ke, webchick, xjm: Include paths are resolved for every resource in a resource collection, instead of once per unique resource type
* #2990664 by nuez, seanB, cbccharlie, Wim Leers, deepaksingh05, Pancho, Chi, wwedding, Berdir, phenaproxima: Media library does not work when Drupal is installed into a sub-directory
* #2979966 by quietone, PieterDC, masipila, heddn, Gábor Hojtsy: Migrate D7 i18n taxonomy term language
* #2993927 by juampynr, quietone, deviantintegral: Taxonomy Term field with Rendered Entity formatter breaks migration
* #3035446 by seanB, bnjmnm, phenaproxima, andrewmacpherson, Wim Leers, alexpott, rainbreaw: Inform assistive tech users about the outcome of using the MediaLibraryWidget dialog
* #3058943 by Mohammed J. Razem, alonaoneill: Fix Media Library module name according to module naming convention
* #3056008 by alexpott, Lendude: Set default window size in \Drupal\FunctionalJavascriptTests\WebDriverTestBase
* #3038350 by seanB, Wim Leers, effulgentsia: Deny access to all media library View Displays if there is no valid state object
* #2763637 by Jo Fitzgerald, quietone, hussainweb, timwood, alexpott, heddn, mikeryan, phenaproxima, maxocub, BenStallings, catch: D7 taxonomy term fields are not migrated with allowed vocabularies
* #3016064 by yogeshmpawar, vacho, msankhala, singhkiran, deepanker_bhalla, gambry, dpi: Improve documentation for Datetime and Datelist #date_timezone property
* #2968170 by joelpittet, idebr, heddn, quietone, mikelutz, tim.plunkett: MenuLinkParent breaks migration when Parent URI is external
* #3059564 by yogeshmpawar, fredysan, init90, joachim, alexpott: error in deprecation note on EntityInterface::link()
* #3056616 by idebr, Pasqualle, init90, alexpott: Remove dead code in NodeTypeForm::actions()
* #3044366 by shaal, kjay, tim.plunkett, bnjmnm, alexpott, pawandubey, smaz, lauriii, markconroy, Gábor Hojtsy: Fix styling of Umami for layout builder