### PR TITLE
[GOVCMSD8-435] Upgrade Drupal core to 8.7.7 from 8.7.6

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,12 +25,12 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "8.7.6",
+        "drupal/core": "8.7.7",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "webflo/drupal-core-strict": "8.7.6"
+        "webflo/drupal-core-strict": "8.7.7"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
-        "drupal/core": "8.7.6",
+        "drupal/core": "8.7.7",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0-rc2",
         "drupal/devel": "2.0",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,4 +1,4 @@
 core = 8.x
 api = 2
 projects[drupal][type] = core
-projects[drupal][version] = 8.7.6
+projects[drupal][version] = 8.7.7


### PR DESCRIPTION
Drupal 8.7.7 is a patch release and there is no security updates. But it does fix a XSS vulnerability. See https://www.drupal.org/node/2780285.

Drupal 8.7.7 introduces a new core_version_requirement key to *.info.yml files, allowing contributed modules to specify specific versions for Drupal core compatibility, as well as to indicate that they are compatible with both Drupal 8 and the forthcoming Drupal 9 release.

**Risk assessment:**

Issue | Assessment | DB/Entity Update | Risk Level
-- | -- | -- | --
[#3006815](https://www.drupal.org/node/3006815) ViewsEntitySchemaSubscriber may fail when a view has a broken handler | The View module will be affected by this change. We need to test views, particularly those have broken/missing handler. | N/A | Low
[#3078001](https://www.drupal.org/node/3078001) Followup minor test fix to not catching exception for invalid 'core_version_requirement' in info.yml files | This change will prevent a module that has invalid 'core_version_requirement' in info.yml file from installing. A warning message will show up but the installation can continue. | N/A | **Moderate**
[#2313917](https://www.drupal.org/node/2313917) Core version key in module's .info.yml doesn't respect core semantic versioning | This change introduces a new core_version_requirement key to *.info.yml files. For instance, core_version_requirement: ^8.7. This is a new feature, any module that doesn't specify the 'core_version_requirement' key in the info.yml file will not be affected. | N/A | Low
[#3075831](https://www.drupal.org/node/3075831) Failing assertions when bundle ID contains only numbers | This change will affect the JSON API and any modules working with JSON API might be affected. This change fixes a very minor bug and makes the JSON API more robust. | N/A | Low
[#3007102](https://www.drupal.org/node/3007102) Migrating to Date-only field does not drop time value | This change will affect a date field migrated from D7. A bug has been reported with this change (https://www.drupal.org/project/drupal/issues/3079805#comment-13250058) that only affects PHPUnit test with PHP5. | N/A | **Moderate**
[#3067889](https://www.drupal.org/node/3067889) Boolean Field On and Off Label not Migrating | This change will affect a Boolean field migrated from D7 to D8 and fixes a bug which the label of the field won't migrate appropriately. | N/A | Low
[#3076609](https://www.drupal.org/node/3076609) CKEditorIntegrationTest fails on Sqlite | This change fixes a CKEditor test bug with Sqlite database. | N/A | Low
[#3076169](https://www.drupal.org/node/3076169) D6 OptionWidgetsField migrate plugin has wrong namespace | This change fixes a typo bug with D6 migrate plugin. | N/A | Low
[#3061610](https://www.drupal.org/node/3061610) Typed Data's EntityDeriver does not derive bundle-level data types when a bundle has the same name as its entity type | This change fixes a entity schema bug that occurs when comment module is installed. | N/A | Low
[#3075661](https://www.drupal.org/node/3075661) Datetime have incorrect Type in phpDoc | This change corrects a type in PHP Doc from string to array. | N/A | Low
[#3043168](https://www.drupal.org/node/3043168) PATCH 405 for untranslatable content entities with different default language than English | This change fixes a bug in which the JSON Api module can not convert non-translatable content correctly. | N/A | Low
[#2984938](https://www.drupal.org/node/2984938) Remember the page you were on and take you back there when switching Workspaces | This change introduces a new feature that takes user back to previous page when switching Workspaces (workspace module). | N/A | Low
[#3073342](https://www.drupal.org/node/3073342) JavaScript tests don't work with Chromedriver 75 and higher | This change fixes a compatible issue with latest Chromedriver for JavaScript tests. | N/A | Low
[#2962765](https://www.drupal.org/node/2962765) Clarify how to set MINK variables at phpunit.xml.dist | This change fixes a minor issue with PHPUnit test for JavaScript tests. | N/A | Low
[#2849413](https://www.drupal.org/node/2849413) Class name must be a valid object or a string error | This change fixes a fatal error with Image module occurred in a rare scenario in which there is a reference to disabled stream wrappers in the database. | N/A | Low
[#3060996](https://www.drupal.org/node/3060996) Fix The "Symfony\Component\BrowserKit\Response::getStatus()" method is deprecated since Symfony 4.3, use getStatusCode() instead. | This change fixes a deprecation warning message while updating via composer. | N/A | Low
[#3074039](https://www.drupal.org/node/3074039) Add a composer conflict for symfony/dom-crawler >=4 to 8.7 only. | This change prevents the test failures on 8.7 without disruption by adding a conflict with dom-crawler 4+ in the core composer.json file. | N/A | Low
[#3073410](https://www.drupal.org/node/3073410) TwigExtension::getUrl() declares the wrong return type. | This change corrects the type of return value of TwigExtension::getUrl() in PHP DOC. | N/A | Low
[#2780285](https://www.drupal.org/node/2780285) XSS in date format configuration. | This change fixes a XSS (Cross-site scripting) vulnerability in which the DateTime subsystem maintainer, discovered an exploitable XSS situation in the date formats configuration. | N/A | **Moderate**

