### PR TITLE
[GOVCMSD8-435] Upgrade Drupal core to 8.7.7 from 8.7.6 (Short branch name)

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,12 +25,12 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "8.7.6",
+        "drupal/core": "8.7.7",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "webflo/drupal-core-strict": "8.7.6"
+        "webflo/drupal-core-strict": "8.7.7"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0-beta9",
         "drupal/context": "4.0-beta2",
-        "drupal/core": "8.7.6",
+        "drupal/core": "8.7.7",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0-rc2",
         "drupal/devel": "2.0",

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,4 +1,4 @@
 core = 8.x
 api = 2
 projects[drupal][type] = core
-projects[drupal][version] = 8.7.6
+projects[drupal][version] = 8.7.7


### PR DESCRIPTION
Short the branch name from feature/GOVCMSD8-435-Core-8_7_7 to feature/GOVCMSD8-435.