### PR TITLE
read from ADMIN_PW secret at Drupal install

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -58,7 +58,7 @@ services:
 
         # Install the site.
         - rm -rf /var/govcms/docroot/profiles/govcms/config/sync # In some cases the sync directory is created and a re-install fails.
-        - cd /var/govcms && drush -r "${DOCROOT}" site:install govcms install_configure_form.update_status_module='array(FALSE,FALSE)' -y
+        - cd /var/govcms && drush -r "${DOCROOT}" site:install govcms install_configure_form.update_status_module='array(FALSE,FALSE)' --account-pass=${ADMIN_PW} -y
         - cd /var/govcms && drush -r "${DOCROOT}" pm:enable govcms8_default_content -y
 
         # Cuts down on image size, although makes initial preview loading slower.


### PR DESCRIPTION
This PR sets the initial password in a secret env var - this will make it easier to test multiple branches at once, and avoid having a new password set on every rebuild.

This password should be rotated regularly inside tugboat.