### PR TITLE
[GOVCMSD8-425]: Change default value of author visibility for content type creation form

### DIFF
--- a/modules/custom/core/govcms_content_types/govcms_content_types.module
+++ b/modules/custom/core/govcms_content_types/govcms_content_types.module
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Implements hook_form_alter().
+ *
+ * @inheritDoc
+ */
+function govcms_content_types_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+
+  // Author information shouldn't be displayed by default for new content types.
+  // If desired, it can be enabled however ISM states individual employees
+  // shouldn't have their names or details present on the website.
+  if ($form_id === "node_type_add_form") {
+    $form['display']['display_submitted']['#default_value'] = 0;
+  }
+
+}


### PR DESCRIPTION
New content types shouldn't by default expose user information and it should be configurable to be enabled. This `form_alter` hook will simply change value of that form component on that form.

This is for ISM compliance, so it's security in nature but doesn't cause any security issues.