### PR TITLE
[GOVCMSD8-557] Add Drupal9 deprecation check to every branch and PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           command: |
             docker cp .circleci/d9-readiness.sh $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.sh
             docker-compose exec -T test /app/d9-readiness.sh
-            docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
+            mkdir -p /tmp/artifacts && docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
       - run:
           name: Lint code
           command: docker-compose exec -T test lint-theme || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,9 @@ jobs:
       - run:
           name: Check Drupal 9 deprecations
           command: |
-            - docker cp .circleci/d9-readiness.sh $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.sh
-            - docker-compose exec -T test /app/d9-readiness.sh
-            - docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
+            docker cp .circleci/d9-readiness.sh $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.sh
+            docker-compose exec -T test /app/d9-readiness.sh
+            docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
       - run:
           name: Lint code
           command: docker-compose exec -T test lint-theme || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,12 @@ jobs:
           name: Run Behat tests with rerun
           command: docker-compose exec -T test behat --format=progress_fail || docker-compose exec -T test behat --format=progress_fail --rerun
       - run:
+          name: Check Drupal 9 deprecations
+          command: |
+            - docker cp .circleci/d9-readiness.sh $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.sh
+            - docker-compose exec test -T /app/d9-readiness.sh
+            - docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
+      - run:
           name: Copy artifacts
           command: mkdir -p /tmp/artifacts/behat && docker cp $(docker-compose -p govcms8 ps -q test):/app/tests/behat/screenshots /tmp/artifacts/behat
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,12 +37,6 @@ jobs:
             docker-compose exec -T test drush st
             docker-compose exec -T test drush pml
       - run:
-          name: Check Drupal 9 deprecations
-          command: |
-            docker cp .circleci/d9-readiness.sh $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.sh
-            docker-compose exec -T test /app/d9-readiness.sh
-            mkdir -p /tmp/artifacts && docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
-      - run:
           name: Lint code
           command: docker-compose exec -T test lint-theme || true
       - run:
@@ -52,6 +46,12 @@ jobs:
           name: Copy artifacts
           command: mkdir -p /tmp/artifacts/behat && docker cp $(docker-compose -p govcms8 ps -q test):/app/tests/behat/screenshots /tmp/artifacts/behat
           when: always
+      - run:
+          name: Check Drupal 9 deprecations
+          command: |
+            docker cp .circleci/d9-readiness.sh $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.sh
+            docker-compose exec -T test /app/d9-readiness.sh
+            mkdir -p /tmp/artifacts && docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
       - store_artifacts:
           path: /tmp/artifacts
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,17 +37,17 @@ jobs:
             docker-compose exec -T test drush st
             docker-compose exec -T test drush pml
       - run:
+          name: Check Drupal 9 deprecations
+          command: |
+            - docker cp .circleci/d9-readiness.sh $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.sh
+            - docker-compose exec -T test /app/d9-readiness.sh
+            - docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
+      - run:
           name: Lint code
           command: docker-compose exec -T test lint-theme || true
       - run:
           name: Run Behat tests with rerun
           command: docker-compose exec -T test behat --format=progress_fail || docker-compose exec -T test behat --format=progress_fail --rerun
-      - run:
-          name: Check Drupal 9 deprecations
-          command: |
-            - docker cp .circleci/d9-readiness.sh $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.sh
-            - docker-compose exec test -T /app/d9-readiness.sh
-            - docker cp $(docker-compose -p govcms8 ps -q test):/app/d9-readiness.log /tmp/artifacts/d9-readiness.log
       - run:
           name: Copy artifacts
           command: mkdir -p /tmp/artifacts/behat && docker cp $(docker-compose -p govcms8 ps -q test):/app/tests/behat/screenshots /tmp/artifacts/behat

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 
 LOG=/app/d9-readiness.log
 
-composer require mglaman/drupal-check
+composer -n require mglaman/drupal-check
 rm -f web/profiles/contrib/govcms/composer.json
 rm -f "${LOG}" && touch "${LOG}"
 
+echo echo -e "\nRUNNING DEPRECATION TEST FOR: GovCMS Profile" | tee -a "${LOG}"
 set +e
-echo echo -e "\nRUNNING DEPRECATION TEST FOR: GovCMS Profile"
 vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}" | tee -a "${LOG}"
 set -e
 
@@ -18,6 +18,15 @@ for module in web/modules/contrib/*; do
         echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}" | tee -a "${LOG}"
         set +e
         vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
+        set -e
+    fi
+done
+
+for theme in web/themes/contrib/*; do
+    if [ -d "${theme}" ]; then
+        echo -e "\nRUNNING DEPRECATION TEST FOR: ${theme}" | tee -a "${LOG}"
+        set +e
+        vendor/bin/drupal-check --no-progress "${theme}" >> "${LOG}"
         set -e
     fi
 done

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -8,14 +8,14 @@ composer -n require mglaman/drupal-check
 rm -f web/profiles/contrib/govcms/composer.json
 rm -f "${LOG}" && touch "${LOG}"
 
-echo -e "\nRUNNING DEPRECATION TEST FOR: GovCMS Profile" | tee -a "${LOG}"
+echo -e "\n [PROFILE] web/profiles/contrib/govcms" | tee -a "${LOG}"
 set +e
 vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}" | tee -a "${LOG}"
 set -e
 
 for theme in web/themes/contrib/*; do
     if [ -d "${theme}" ]; then
-        echo -e "\nRUNNING DEPRECATION TEST FOR: ${theme}" | tee -a "${LOG}"
+        echo -e "\n [THEME] ${theme}" | tee -a "${LOG}"
         set +e
         vendor/bin/drupal-check --no-progress "${theme}" >> "${LOG}"
         set -e
@@ -24,7 +24,7 @@ done
 
 for module in web/modules/contrib/*; do
     if [ -d "${module}" ]; then
-        echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}" | tee -a "${LOG}"
+        echo -e "\n [MODULE] ${module}" | tee -a "${LOG}"
         set +e
         vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
         set -e

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -30,3 +30,6 @@ for module in web/modules/contrib/*; do
         set -e
     fi
 done
+
+WITH_SUMMARY=(cat "${LOG}" | grep "[ ]*\[" ; cat "${LOG}")
+echo "$WITH_SUMMARY" > "${LOG}"

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -8,25 +8,25 @@ composer -n require mglaman/drupal-check
 rm -f web/profiles/contrib/govcms/composer.json
 rm -f "${LOG}" && touch "${LOG}"
 
-echo echo -e "\nRUNNING DEPRECATION TEST FOR: GovCMS Profile" | tee -a "${LOG}"
+echo -e "\nRUNNING DEPRECATION TEST FOR: GovCMS Profile" | tee -a "${LOG}"
 set +e
 vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}" | tee -a "${LOG}"
 set -e
-
-for module in web/modules/contrib/*; do
-    if [ -d "${module}" ]; then
-        echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}" | tee -a "${LOG}"
-        set +e
-        vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
-        set -e
-    fi
-done
 
 for theme in web/themes/contrib/*; do
     if [ -d "${theme}" ]; then
         echo -e "\nRUNNING DEPRECATION TEST FOR: ${theme}" | tee -a "${LOG}"
         set +e
         vendor/bin/drupal-check --no-progress "${theme}" >> "${LOG}"
+        set -e
+    fi
+done
+
+for module in web/modules/contrib/*; do
+    if [ -d "${module}" ]; then
+        echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}" | tee -a "${LOG}"
+        set +e
+        vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
         set -e
     fi
 done

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -10,12 +10,12 @@ rm -f "${LOG}" && touch "${LOG}"
 
 set +e
 echo echo -e "\nRUNNING DEPRECATION TEST FOR: GovCMS Profile"
-vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}"
+vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}" | tee "${LOG}"
 set -e
 
 for module in web/modules/contrib/*; do
     if [ -d "${module}" ]; then
-        echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}"
+        echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}" | tee "${LOG}"
         set +e
         vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
         set -e

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -32,7 +32,7 @@ for module in web/modules/contrib/*; do
     if [ -d "${module}" ]; then
         echo -e "\n [MODULE] ${module}" | tee -a "${LOG}"
         set +e
-        drush en -y "$(basename ${module})"
+        vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
         set -e
     fi
 done

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -2,22 +2,22 @@
 IFS=$'\n\t'
 set -euo pipefail
 
-LOG=/app/d9-deprecations.log
+LOG=/app/d9-readiness.log
 
 composer require mglaman/drupal-check
 rm -f web/profiles/contrib/govcms/composer.json
 rm -f "${LOG}" && touch "${LOG}"
 
 set +e
-echo "DEPRECATION TEST FOR: GovCMS Profile"
-vendor/bin/drupal-check web/profiles/contrib/govcms > "${LOG}"
+echo echo -e "\nRUNNING DEPRECATION TEST FOR: GovCMS Profile"
+vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}"
 set -e
 
 for module in web/modules/contrib/*; do
     if [ -d "${module}" ]; then
-        echo "DEPRECATION TEST FOR: ${module}"
+        echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}"
         set +e
-        vendor/bin/drupal-check "${module}" >> "${LOG}"
+        vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
         set -e
     fi
 done

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -31,5 +31,5 @@ for module in web/modules/contrib/*; do
     fi
 done
 
-WITH_SUMMARY=(cat "${LOG}" | grep "[ ]*\[" ; cat "${LOG}")
+WITH_SUMMARY=`cat "${LOG}" | grep "[ ]*\[" ; cat "${LOG}"`
 echo "$WITH_SUMMARY" > "${LOG}"

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -2,15 +2,22 @@
 IFS=$'\n\t'
 set -euo pipefail
 
+##
+# Test for deprecated code in GovCMS profile, themes, and its contrib.
+# @see https://github.com/mglaman/drupal-check <-- we're using this here.
+# @see https://github.com/drupal8-rector/drupal8-rector
+# @see https://www.drupal.org/project/upgrade_status
+
 LOG=/app/d9-readiness.log
 
 composer -n require mglaman/drupal-check
 rm -f web/profiles/contrib/govcms/composer.json
 rm -f "${LOG}" && touch "${LOG}"
 
+echo -e " [💥] GovCMS Distribution Drupal 9 Deprecation Testing log [💥]"
 echo -e "\n [PROFILE] web/profiles/contrib/govcms" | tee -a "${LOG}"
 set +e
-vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}" | tee -a "${LOG}"
+vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms >> "${LOG}"
 set -e
 
 for theme in web/themes/contrib/*; do

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -10,12 +10,12 @@ rm -f "${LOG}" && touch "${LOG}"
 
 set +e
 echo echo -e "\nRUNNING DEPRECATION TEST FOR: GovCMS Profile"
-vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}" | tee "${LOG}"
+vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms > "${LOG}" | tee -a "${LOG}"
 set -e
 
 for module in web/modules/contrib/*; do
     if [ -d "${module}" ]; then
-        echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}" | tee "${LOG}"
+        echo -e "\nRUNNING DEPRECATION TEST FOR: ${module}" | tee -a "${LOG}"
         set +e
         vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
         set -e

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -14,7 +14,7 @@ composer -n require mglaman/drupal-check
 rm -f web/profiles/contrib/govcms/composer.json
 rm -f "${LOG}" && touch "${LOG}"
 
-echo -e " [💥] GovCMS Distribution Drupal 9 Deprecation Testing log [💥]"
+echo -e "\n [💥] GovCMS Distribution Drupal 9 Deprecation Testing log [💥]" | tee -a "${LOG}"
 echo -e "\n [PROFILE] web/profiles/contrib/govcms" | tee -a "${LOG}"
 set +e
 vendor/bin/drupal-check --no-progress web/profiles/contrib/govcms >> "${LOG}"

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -10,7 +10,6 @@ set -euo pipefail
 
 LOG=/app/d9-readiness.log
 
-composer -n require mglaman/drupal-check
 rm -f web/profiles/contrib/govcms/composer.json
 rm -f "${LOG}" && touch "${LOG}"
 
@@ -33,7 +32,7 @@ for module in web/modules/contrib/*; do
     if [ -d "${module}" ]; then
         echo -e "\n [MODULE] ${module}" | tee -a "${LOG}"
         set +e
-        vendor/bin/drupal-check --no-progress "${module}" >> "${LOG}"
+        drush en -y "$(basename ${module})"
         set -e
     fi
 done

--- a/.circleci/d9-readiness.sh
+++ b/.circleci/d9-readiness.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+IFS=$'\n\t'
+set -euo pipefail
+
+LOG=/app/d9-deprecations.log
+
+composer require mglaman/drupal-check
+rm -f web/profiles/contrib/govcms/composer.json
+rm -f "${LOG}" && touch "${LOG}"
+
+set +e
+echo "DEPRECATION TEST FOR: GovCMS Profile"
+vendor/bin/drupal-check web/profiles/contrib/govcms > "${LOG}"
+set -e
+
+for module in web/modules/contrib/*; do
+    if [ -d "${module}" ]; then
+        echo "DEPRECATION TEST FOR: ${module}"
+        set +e
+        vendor/bin/drupal-check "${module}" >> "${LOG}"
+        set -e
+    fi
+done

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -4,3 +4,5 @@ FROM ${CLI_IMAGE} as cli
 FROM amazeeio/php:7.2-fpm
 
 COPY --from=cli /app /app
+
+RUN apk add git

--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -28,6 +28,8 @@
         "drupal/core-recommended": "8.8.1",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
+        "mglaman/drupal-check": "dev-master",
+        "drupal/upgrade_status": "^2.0",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3"
     },


### PR DESCRIPTION
supersedes #328 

This runs the d9 compatibility tests against every branch and PR, and saves the test artifact

The
```
        "mglaman/drupal-check": "dev-master",
        "drupal/upgrade_status": "^2.0",
```
modules will only be present in local GovCMS8 builds, they will not be added to the distro or published into images