### PR TITLE
[GOVCMSD8-557] Make GovCMS profile Drupal9 ready

### DIFF
--- a/govcms.info.yml
+++ b/govcms.info.yml
@@ -28,6 +28,7 @@ dependencies:
   - menu_ui
   - node
   - options
+  - path_alias
   - quickedit
   - rdf
   - responsive_image

--- a/govcms.info.yml
+++ b/govcms.info.yml
@@ -1,7 +1,7 @@
 name:                   GovCMS
 type:                   profile
 description:            'A GovCMS Drupal Distribution for government and the public sector in Australia.'
-core:                   8.x
+core_version_requirement: ^8.8 || ^9
 
 distribution:
   name:                 GovCMS

--- a/govcms.install
+++ b/govcms.install
@@ -5,9 +5,9 @@
  * Install, update and uninstall hooks for the govCMS profile.
  */
 
-use Drupal\user\Entity\User;
 use Drupal\user\RoleInterface;
 use Drupal\shortcut\Entity\Shortcut;
+use Drupal\user\UserInterface;
 
 /**
  * Define a default theme constant.
@@ -29,7 +29,7 @@ define('GOVCMS_DEFAULT_ADMIN_THEME', 'adminimal_theme');
 function govcms_install() {
   // Restrict user registration to admin role creation.
   $user_settings = \Drupal::configFactory()->getEditable('user.settings');
-  $user_settings->set('register', USER_REGISTER_ADMINISTRATORS_ONLY)->save(TRUE);
+  $user_settings->set('register', UserInterface::REGISTER_ADMINISTRATORS_ONLY)->save(TRUE);
 
   // Allow all users to use search.
   user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['search content']);

--- a/modules/custom/core/govcms_media/src/Element/Upload.php
+++ b/modules/custom/core/govcms_media/src/Element/Upload.php
@@ -91,11 +91,11 @@ class Upload extends FileElement {
     $upload = \Drupal::request()->files->get($id);
 
     if ($upload instanceof UploadedFile) {
-      $destination = \Drupal::service('file_system')
-        ->realPath($element['#upload_location']);
+      $file_service = \Drupal::service('file_system');
+      $destination = $file_service->realPath($element['#upload_location']);
 
       $name = file_munge_filename($upload->getClientOriginalName(), NULL);
-      $name = file_create_filename($name, $destination);
+      $name = $file_service->createFilename($name, $destination);
       $name = $upload->move($destination, $name)->getFilename();
 
       $uri = $element['#upload_location'];

--- a/modules/custom/core/govcms_media/src/Form/BulkUploadForm.php
+++ b/modules/custom/core/govcms_media/src/Form/BulkUploadForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\govcms_media\Form;
 
+use Drupal\Component\Utility\Environment;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -84,7 +85,7 @@ class BulkUploadForm extends FormBase {
     ];
 
     $variables = [
-      '@max_size' => static::bytesToString(file_upload_max_size()),
+      '@max_size' => static::bytesToString(Environment::getUploadMaxSize()),
       '@extensions' => Element::oxford($extensions),
     ];
     $form['dropzone']['#description'] = $this->t('You can upload as many files as you like. Each file can be up to @max_size in size. The following file extensions are accepted: @extensions', $variables);
@@ -161,7 +162,12 @@ class BulkUploadForm extends FormBase {
         $entity = $this->helper->createFromInput($file);
       }
       catch (IndeterminateBundleException $e) {
-        drupal_set_message('error', (string) $e);
+        if (isset($form['dropzone'])) {
+          $form_state->setError($form['dropzone'], $e->__toString());
+        }
+        else {
+          $this->messenger()->addError($e->__toString()); 
+        }
         continue;
       }
 

--- a/modules/custom/core/govcms_media/src/MediaHelper.php
+++ b/modules/custom/core/govcms_media/src/MediaHelper.php
@@ -3,6 +3,7 @@
 namespace Drupal\govcms_media;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\file\FileInterface;
 use Drupal\file\Plugin\Field\FieldType\FileItem;
 use Drupal\govcms_media\Exception\IndeterminateBundleException;
@@ -148,7 +149,7 @@ class MediaHelper {
    * @return \Drupal\file\FileInterface|false
    *   The final file entity (unsaved), or FALSE if an error occurred.
    */
-  public static function useFile(MediaInterface $entity, FileInterface $file, $replace = FILE_EXISTS_RENAME) {
+  public static function useFile(MediaInterface $entity, FileInterface $file, $replace = FileSystemInterface::EXISTS_RENAME) {
     $field = static::getSourceField($entity);
     $field->setValue($file);
 
@@ -192,7 +193,11 @@ class MediaHelper {
     $item = static::getSourceField($entity)->first();
 
     $dir = $item->getUploadLocation();
-    $is_ready = file_prepare_directory($dir, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
+    $is_ready = \Drupal::service('file_system')->prepareDirectory(
+      $dir,
+      FileSystemInterface::CREATE_DIRECTORY | 
+      FileSystemInterface::MODIFY_PERMISSIONS
+    );
 
     if ($is_ready) {
       return $dir;

--- a/modules/custom/optional/govcms8_default_content/govcms8_default_content.drush.inc
+++ b/modules/custom/optional/govcms8_default_content/govcms8_default_content.drush.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\govcms8_default_content\InstallHelper;
+use Drush\Drush;
 
 /**
  * Implements hook_drush_command().
@@ -29,7 +30,7 @@ function govcms8_default_content_drush_command() {
  */
 function drush_govcms8_default_content_import() {
   \Drupal::classResolver()->getInstanceFromDefinition(InstallHelper::class)->importContent();
-  drush_log(dt('Imported GovCMS8 default content.'), 'ok');
+  Drush::service('logger')->info(dt('Imported GovCMS8 default content.'));
 }
 
 /**
@@ -37,5 +38,5 @@ function drush_govcms8_default_content_import() {
  */
 function drush_govcms8_default_content_rollback() {
   \Drupal::classResolver()->getInstanceFromDefinition(InstallHelper::class)->deleteImportedContent();
-  drush_log(dt('Rolled back GovCMS8 default content.'), 'ok');
+  Drush::service('logger')->info(dt('Rolled back GovCMS8 default content.'));
 }

--- a/modules/custom/optional/govcms8_default_content/src/Commands/Govcms8DefaultContentCommands.php
+++ b/modules/custom/optional/govcms8_default_content/src/Commands/Govcms8DefaultContentCommands.php
@@ -27,7 +27,7 @@ class Govcms8DefaultContentCommands extends DrushCommands {
    */
   public function defaultContentImport() {
     \Drupal::classResolver()->getInstanceFromDefinition(InstallHelper::class)->importContent();
-    drush_log(dt('Imported GovCMS8 default content.'), 'ok');
+    $this->logger()->info(dt('Imported GovCMS8 default content.'));
   }
 
   /**
@@ -39,7 +39,7 @@ class Govcms8DefaultContentCommands extends DrushCommands {
    */
   public function defaultContentRollback() {
     \Drupal::classResolver()->getInstanceFromDefinition(InstallHelper::class)->deleteImportedContent();
-    drush_log(dt('Rolled back GovCMS8 default content.'), 'ok');
+    $this->logger()->info(dt('Rolled back GovCMS8 default content.'));
   }
 
 }

--- a/modules/custom/optional/govcms8_default_content/src/InstallHelper.php
+++ b/modules/custom/optional/govcms8_default_content/src/InstallHelper.php
@@ -5,7 +5,8 @@ namespace Drupal\govcms8_default_content;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Path\AliasManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\file\Entity\File;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -49,6 +50,13 @@ class InstallHelper implements ContainerInjectionInterface {
   protected $state;
 
   /**
+   * File system handler.
+   * 
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
    * Constructs a new InstallHelper object.
    *
    * @param \Drupal\Core\Path\AliasManagerInterface $aliasManager
@@ -60,11 +68,12 @@ class InstallHelper implements ContainerInjectionInterface {
    * @param \Drupal\Core\State\StateInterface $state
    *   State service.
    */
-  public function __construct(AliasManagerInterface $aliasManager, EntityTypeManagerInterface $entityTypeManager, ModuleHandlerInterface $moduleHandler, StateInterface $state) {
+  public function __construct(AliasManagerInterface $aliasManager, EntityTypeManagerInterface $entityTypeManager, ModuleHandlerInterface $moduleHandler, StateInterface $state, FileSystemInterface $fileSys) {
     $this->aliasManager = $aliasManager;
     $this->entityTypeManager = $entityTypeManager;
     $this->moduleHandler = $moduleHandler;
     $this->state = $state;
+    $this->fileSystem = $fileSys;
   }
 
   /**
@@ -329,10 +338,10 @@ class InstallHelper implements ContainerInjectionInterface {
    */
   public function saveFile($file_name) {
     $path = 'public://govcms8-demo';
-    if (file_prepare_directory($path, FILE_CREATE_DIRECTORY)) {
+    if ($this->fileSystem->prepareDirectory($path, FileSystemInterface::CREATE_DIRECTORY)) {
       $source = DRUPAL_ROOT . '/' . drupal_get_path('module', 'govcms8_default_content') . '/import/images/' . $file_name;
       $data = file_get_contents($source);
-      return file_save_data($data, "public://govcms8-demo/" . $file_name, FILE_EXISTS_RENAME);
+      return file_save_data($data, "public://govcms8-demo/" . $file_name, FileSystemInterface::EXISTS_RENAME);
     }
   }
 
@@ -476,7 +485,7 @@ class InstallHelper implements ContainerInjectionInterface {
    */
   protected function fileUnmanagedCopy($path) {
     $filename = basename($path);
-    return file_unmanaged_copy($path, 'public://' . $filename, FILE_EXISTS_REPLACE);
+    return $this->fileSystem->copy($path, 'public://' . $filename, FileSystemInterface::EXISTS_REPLACE);
   }
 
 }

--- a/modules/custom/optional/govcms8_default_content/src/InstallHelper.php
+++ b/modules/custom/optional/govcms8_default_content/src/InstallHelper.php
@@ -24,7 +24,7 @@ class InstallHelper implements ContainerInjectionInterface {
   /**
    * The path alias manager.
    *
-   * @var \Drupal\Core\Path\AliasManagerInterface
+   * @var \Drupal\path_alias\AliasManagerInterface
    */
   protected $aliasManager;
 
@@ -59,7 +59,7 @@ class InstallHelper implements ContainerInjectionInterface {
   /**
    * Constructs a new InstallHelper object.
    *
-   * @param \Drupal\Core\Path\AliasManagerInterface $aliasManager
+   * @param \Drupal\path_alias\AliasManagerInterface $aliasManager
    *   The path alias manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Entity type manager.
@@ -67,6 +67,8 @@ class InstallHelper implements ContainerInjectionInterface {
    *   Module handler.
    * @param \Drupal\Core\State\StateInterface $state
    *   State service.
+   * @param \Drupal\Core\File\FileSystemInterface $fileSys
+   *   File system service.
    */
   public function __construct(AliasManagerInterface $aliasManager, EntityTypeManagerInterface $entityTypeManager, ModuleHandlerInterface $moduleHandler, StateInterface $state, FileSystemInterface $fileSys) {
     $this->aliasManager = $aliasManager;
@@ -81,10 +83,11 @@ class InstallHelper implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('path.alias_manager'),
+      $container->get('path_alias.manager'),
       $container->get('entity_type.manager'),
       $container->get('module_handler'),
-      $container->get('state')
+      $container->get('state'),
+      $container->get('file_system')
     );
   }
 

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -10,6 +10,7 @@ namespace DrupalProject\composer;
 use Composer\Script\Event;
 use Composer\Semver\Comparator;
 use DrupalFinder\DrupalFinder;
+use Drupal\Core\Site\Settings;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
@@ -41,7 +42,7 @@ class ScriptHandler {
       require_once $drupalRoot . '/core/includes/bootstrap.inc';
       require_once $drupalRoot . '/core/includes/install.inc';
       $settings['config_directories'] = [
-        CONFIG_SYNC_DIRECTORY => (object) [
+        Settings::get('config_sync_directory') => (object) [
           'value' => Path::makeRelative($drupalFinder->getComposerRoot() . '/config/sync', $drupalRoot),
           'required' => TRUE,
         ],


### PR DESCRIPTION

Status | File name | Line | Error
-- | -- | -- | --
Fix now | web/profiles/contrib/govcms/govcms.install | 32 | Call to deprecated constant USER_REGISTER_ADMINISTRATORS_ONLY: Deprecated in drupal:8.3.0 and is removed from drupal:9.0.0. Use \Drupal\user\UserInterface::REGISTER_ADMINISTRATORS_ONLY instead.
Fix now | web/profiles/contrib/govcms/modules/custom/core/govcms_media/src/Element/Upload.php | 98 | Call to deprecated function file_create_filename(). Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::createFilename().
Fix now | web/profiles/contrib/govcms/modules/custom/core/govcms_media/src/Form/BulkUploadForm.php | 87 | Call to deprecated function file_upload_max_size(). Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Component\Utility\Environment::getUploadMaxSize() instead.
Fix now | web/profiles/contrib/govcms/modules/custom/core/govcms_media/src/Form/BulkUploadForm.php | 164 | Call to deprecated function drupal_set_message(). Deprecated in drupal:8.5.0 and is removed from drupal:9.0.0. Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.
Fix now | web/profiles/contrib/govcms/modules/custom/core/govcms_media/src/MediaHelper.php | 151 | Call to deprecated constant FILE_EXISTS_RENAME: Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::EXISTS_RENAME.
Fix now | web/profiles/contrib/govcms/modules/custom/core/govcms_media/src/MediaHelper.php | 195 | Call to deprecated constant FILE_CREATE_DIRECTORY: Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY.
Fix now | web/profiles/contrib/govcms/modules/custom/core/govcms_media/src/MediaHelper.php | 195 | Call to deprecated constant FILE_MODIFY_PERMISSIONS: Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::MODIFY_PERMISSIONS.
Fix now | web/profiles/contrib/govcms/modules/custom/core/govcms_media/src/MediaHelper.php | 195 | Call to deprecated function file_prepare_directory(). Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::prepareDirectory().
Check manually | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/govcms8_default_content.drush.inc | 32 | Call to deprecated function drush_log().
Check manually | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/govcms8_default_content.drush.inc | 40 | Call to deprecated function drush_log().
Check manually | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/src/Commands/Govcms8DefaultContentCommands.php | 30 | Call to deprecated function drush_log().
Check manually | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/src/Commands/Govcms8DefaultContentCommands.php | 42 | Call to deprecated function drush_log().
Fix now | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/src/InstallHelper.php | 63 | Parameter $aliasManager of method Drupal\govcms8_default_content\InstallHelper::__construct() has typehint with deprecated interface Drupal\Core\Path\AliasManagerInterface. Deprecated in drupal:8.8.0 and is removed from drupal:9.0.0. Use \Drupal\path_alias\AliasManagerInterface.
Fix now | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/src/InstallHelper.php | 332 | Call to deprecated constant FILE_CREATE_DIRECTORY: Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY.
Fix now | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/src/InstallHelper.php | 332 | Call to deprecated function file_prepare_directory(). Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::prepareDirectory().
Fix now | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/src/InstallHelper.php | 335 | Call to deprecated constant FILE_EXISTS_RENAME: Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::EXISTS_RENAME.
Fix now | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/src/InstallHelper.php | 479 | Call to deprecated constant FILE_EXISTS_REPLACE: Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::EXISTS_REPLACE.
Fix now | web/profiles/contrib/govcms/modules/custom/optional/govcms8_default_content/src/InstallHelper.php | 479 | Call to deprecated function file_unmanaged_copy(). Deprecated in drupal:8.7.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::copy().
Fix now | web/profiles/contrib/govcms/scripts/composer/ScriptHandler.php | 44 | Call to deprecated constant CONFIG_SYNC_DIRECTORY: Deprecated in drupal:8.8.0 and is removed from drupal:9.0.0. Use \Drupal\Core\Site\Settings::get('config_sync_directory') instead.
Check manually | web/profiles/contrib/govcms/govcms.info.yml | 0 | Add core_version_requirement: ^8 \|\| ^9 to govcms.info.yml to designate that the module is compatible with Drupal 9. See https://www.drupal.org/node/3070687.

