### PR TITLE
[GOVCMSD8-512] update search_api_solr module 3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "drupal/robotstxt": "1.2",
         "drupal/scheduled_transitions": "1.0.0-rc1",
         "drupal/search_api": "1.11",
-        "drupal/search_api_solr": "2.2",
+        "drupal/search_api_solr": "4.0-beta1",
         "drupal/search_api_attachments": "1.0-beta13",
         "drupal/seckit": "1.1",
         "drupal/shield": "1.2",

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "drupal/robotstxt": "1.2",
         "drupal/scheduled_transitions": "1.0.0-rc1",
         "drupal/search_api": "1.11",
-        "drupal/search_api_solr": "4.0-beta1",
+        "drupal/search_api_solr": "3.9",
         "drupal/search_api_attachments": "1.0-beta13",
         "drupal/seckit": "1.1",
         "drupal/shield": "1.2",


### PR DESCRIPTION
# search_api_solr 3.9
## Release notes
Another maintenance release of Search API Solr Search 8.x-3.x. It supports upgrade paths from any previous 8.x version including Search API Solr Multilingual 8.x-1.x!
The big changes in 3.x compared to 2.x:

We collapsed the features of the Standard Backend, both Multilingual Backends and the "Any Schema" Backend into a one new unified Solr Backend. There's a migration path :-)
Mulitisite is back! Select "Clone for Multisite" in an Index' operations, save the Clone Form, export the cloned index config (and probably the server config), deploy the config to a different site, configure a search View as usual, enjoy! ;-)
Spellchecking is now configurable like Suggesters. Use the standard filed configuration to decide which fields should feed the spellcheck catalog
We now distinguish between NGram and EdgeNGram. Both field types are fully configurable via Drupal config files.
We upgraded to solarium 5.0 and therefore require at least PHP 7.1
Experimental support for installation via Ludwig (removed with 8.x-3.6 because Ludwig isn't able to manage conflicting requirements in a reliable way which might lead to fatal errors. Use composer!)
Solr 7/8 compatible implementation of index time boosting of terms and documents
Configurable MoreLikeThis parameters per index
Support for Solr Cloud exclusive features