### PR TITLE
[GOVCMSD8-511] Update search_api_attachments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "drupal/scheduled_transitions": "1.0.0-rc1",
         "drupal/search_api": "1.11",
         "drupal/search_api_solr": "2.2",
-        "drupal/search_api_attachments": "1.0-beta13",
+        "drupal/search_api_attachments": "1.0-beta16",
         "drupal/seckit": "1.1",
         "drupal/shield": "1.2",
         "drupal/simple_oauth": "3.14",


### PR DESCRIPTION
# search_api_attachments 8.x-1.0-beta16
## Release notes
This is D8 beta16 release of search_api_attachments module.

This module depends on search_api that is stable, but search_api_attachments is not yet stable and so not recommended to use in production.

Especially, note that there is no data update path for this module's configuration!

This release :

Fixes two bugs and gets rid of some deprecated methods usage.

Main notable commits since beta15 version :

* Issue #3117949 by drunken monkey, izus: Improve exception handling in FilesExtractor
* Issue #3099352 by sandboxpl, izus: TypeError during cron run when entity referenced by file doesn't exist anymore