### PR TITLE
Fixed lint-theme not failing on fail and excluded node_modules.

### DIFF
--- a/.docker/scripts/lint-theme
+++ b/.docker/scripts/lint-theme
@@ -6,7 +6,7 @@ APP_DIR=${APP_DIR:-/app}
 PROFILE_DIR=${PROFILE_DIR:-${APP_DIR}/web}
 
 # Lint code.
-${APP_DIR}/tests/vendor/bin/parallel-lint --exclude /app/tests/vendor -e php,inc,module,theme,install,profile,test ${PROFILE_DIR}/themes/custom
+${APP_DIR}/tests/vendor/bin/parallel-lint --exclude /app/tests/vendor --exclude ${PROFILE_DIR}/themes/custom/*/node_modules -e php,inc,module,theme,install,profile,test ${PROFILE_DIR}/themes/custom
 
 # Check code standards.
 ${APP_DIR}/tests/vendor/bin/phpcs --standard=${APP_DIR}/tests/phpcs.xml ${PROFILE_DIR}/themes/custom

--- a/.docker/scripts/lint-theme
+++ b/.docker/scripts/lint-theme
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Code linting for SaaS project.
+set -e
 
 APP_DIR=${APP_DIR:-/app}
 PROFILE_DIR=${PROFILE_DIR:-${APP_DIR}/web}

--- a/tests/phpcs.xml
+++ b/tests/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="vahiscv">
-  <description>PHPCS Standard for a GoVCMS8 website, based on Drupal standards.
+<ruleset name="govcms8">
+  <description>PHPCS Standard for a GovCMS8 website, based on Drupal standards.
   </description>
 
   <rule ref="Drupal"/>
@@ -23,6 +23,9 @@
   <!-- Exclude all JS library files. -->
   <exclude-pattern>*library*\.js</exclude-pattern>
   <exclude-pattern>*libraries*\.js</exclude-pattern>
+
+  <!-- Exclude node_modules directory. -->
+  <exclude-pattern>web/themes/custom/*/node_modules/*</exclude-pattern>
 
   <!-- Exclude all features-generated files. -->
   <exclude-pattern>*\.bean\.*</exclude-pattern>


### PR DESCRIPTION
This is a commutative PR that addresses 2 things:
- Fixes `lint-theme` not returning a non-zero code when standards are not met. Note that CI config for SaaS has a value to always bypass lint errors, so this change will not affect SaaS builds.
- Adds ignoring of `node_modules` to the parallel-lint and PHPCS target. This has been requested in https://github.com/govCMS/govCMS8/issues/224 and added as 2 PRs: [223](https://github.com/govCMS/govCMS8/pull/223) and [222](https://github.com/govCMS/govCMS8/pull/222), which were closed with a reference to the `govcms8-scaffold` project's PR [12](https://github.com/govCMS/govcms8-scaffold/pull/12).  While that PR is being in waiting for a year now, existing and new SaaS projects cannot use code linting functionality in full.