### PR TITLE
[GOVCMSD8-609] Update webform 5.13.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
         "drupal/update_notifications_disable": "1.0",
         "drupal/username_enumeration_prevention": "1.0-beta2",
         "drupal/video_embed_field": "2.0",
-        "drupal/webform": "5.8",
+        "drupal/webform": "5.13",
         "oomphinc/composer-installers-extender": "^1.1",
         "swiftmailer/swiftmailer": "5.4.12",
         "symfony/event-dispatcher": "4.3.11 as 3.4.35",

--- a/composer.json
+++ b/composer.json
@@ -167,6 +167,9 @@
                 "The tfa.settings route should use the permission 'admin tfa settings' - https://www.drupal.org/project/tfa/issues/2943972": "https://www.drupal.org/files/issues/2943972-2.patch",
                 "Bad UX around 'required to setup TFA' concept and users who have skipped validation too many times - https://www.drupal.org/project/tfa/issues/2937336": "https://www.drupal.org/files/issues/2019-03-01/2937336-17.patch",
                 "Users' recovery codes exposed to admin users - https://www.drupal.org/project/tfa/issues/3075304": "https://www.drupal.org/files/issues/2019-08-16/tfa-3075304_2.patch"
+            },
+            "drupal/webform": {
+                "Undefined index: messages - https://www.drupal.org/files/issues/2020-05-18/3137625-3.patch" :"https://www.drupal.org/files/issues/2020-05-18/3137625-3.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,9 @@
                 "Users' recovery codes exposed to admin users - https://www.drupal.org/project/tfa/issues/3075304": "https://www.drupal.org/files/issues/2019-08-16/tfa-3075304_2.patch"
             },
             "drupal/webform": {
-                "Undefined index: messages - https://www.drupal.org/files/issues/2020-05-18/3137625-3.patch" :"https://www.drupal.org/files/issues/2020-05-18/3137625-3.patch"
+                "Undefined index: messages - https://www.drupal.org/project/webform/issues/3137625" :"https://www.drupal.org/files/issues/2020-05-18/3137625-3.patch",
+                "Email from name cannot be longer than 128 characters - https://www.drupal.org/project/webform/issues/3142807": "https://www.drupal.org/files/issues/2020-05-26/3142807-9.patch",
+                "Email confirmation clientside validation not working - https://www.drupal.org/project/webform/issues/3138266": "https://www.drupal.org/files/issues/2020-05-20/3138266-5.patch"
             }
         }
     },


### PR DESCRIPTION
# webform 5.13
## Changes since 8.x-5.12:
#3136574 by jrockowitz: Allow file upload extension list to include commas
#3136423 by hocu: Replace w3schools examples with relevant MDN documentation page links
#3136232 by jrockowitz: Overriding required message for select other only applies to original field
#3136062 by jrockowitz, jibran: Element contains ignored/unsupported properties: #equal_stepwise_validate
#3134549 by bighappyface, jrockowitz: Success Messages For Remote Post Handler
#3135574 by jrockowitz: Counter Maximum JS does not match validation
#3135075 by AndrewsizZ, jrockowitz: Replace assertEqual() or assertSame() on two calls to count() with assertCount()
#3135006 by bighappyface: Webform Handler Token String Conversion Notice
#3135076 by AndrewsizZ: Replace assertions involving calls to is_array() with assertIsArray()/assertIsNotArray()
#3135070 by AndrewsizZ: Replace assert* involving an instanceof operator with assertInstanceOf()/assertNotInstanceOf()
#3135072 by AndrewsizZ: Replace assertions involving calls to file_exists with assertFileExists()/assertFileNotExists()
#3135160 by AndrewsizZ: Replace assertions involving calls to is_string() with assertIsString()/assertIsNotString()
#3135161 by AndrewsizZ: Replace assert*() involving equality comparison operators with assert(Not)(Equals|Same)
#3135164 by AndrewsizZ: Clean up all the remaining $this->assert()
#3134833 by jrockowitz: Subelement weight fails custom settings validation
#3119248 by jrockowitz, cleo7186: Editing Ajax Enabled Wizard Webform Shows Submit Button
#3134351 by Berdir: Notice: Undefined index: fieldname in ReferenceSelectWidget::formElement()
#3133393 by jrockowitz, Matthijs: Select widget of webform field doesn't use its entity reference selection plugin
#3134159 by jrockowitz: Custom composite - Files don't attach to email
#3132909 by jrockowitz: Adding a webform in an entity reference field (in a paragraph) fails
#3134367 by dennis_meuwissen: Respect an outgoing link's target when warning the user about unsaved changes in iOS
#3134439 by AndrewsizZ: Replace assertions involving calls to empty() with assertEmpty()/assertNotEmpty()/assertArrayNotHasKey()
#3134446 by AndrewsizZ: Replace assertions involving calls to isset() with assertArrayHasKey()/assertArrayNotHasKey
#3133271 by jrockowitz: Support NULL value when decoding YAML
#3134231 by jrockowitz: Notice: Trying to access array offset on value
#3134289 by jrockowitz: Cleanup ::getSortedDefinitions
#3132177 by jrockowitz: Allow custom YAML data in Remote post to be typecast
#3133208 by jrockowitz: Help text does not display before/after title on Email confirm element
#3133717 by jrockowitz: Custom third party settings are lost when General settings page is saved
#3133945 by douggreen: Remove .orig files accidentally committed
#3133888 by jrockowitz: Notice: Uninitialized string offset: 0 in Drupal\Core\Render\Element::property() (line 27 of core/lib/Drupal/Core/Render/Element.php)