### PR TITLE
[GOVCMSD8-627] Prevent user roles from being configured as the admin role.

### DIFF
--- a/govcms.info.yml
+++ b/govcms.info.yml
@@ -90,6 +90,7 @@ dependencies:
   - govcms_foi
   - govcms_news_and_media
   - govcms_standard_page
+  - govcms_security
 
 dependencies_optional:
   - govcms8_default_content

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -4,3 +4,25 @@
  * @file
  * Contains install and update functions for the module.
  */
+
+/**
+ * Reset the 'is_admin' flag to false for all user roles.
+ */
+
+function govcms_security_update_8001() {
+  $config_factory = \Drupal::configFactory();
+  // All roles.
+  $roles = $config_factory->listAll('user.role');
+  if ($roles) {
+    // Update all roles
+    foreach ($roles as $role) {
+      // Role setting object.
+      $role_setting = $config_factory->getEditable($role);
+      if ($role_setting) {
+        // No role should be admin.
+        $role_setting->set('is_admin', false);
+        $role_setting->save(TRUE);
+      }
+    }
+  }
+}

--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -4,3 +4,15 @@
  * @file
  * Contains install and update functions.
  */
+
+/**
+ * Implement hook_form_FORM_ID_alter()
+ */
+function govcms_security_form_user_admin_settings_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  if (isset($form['admin_role']['user_admin_role'])) {
+    // Disable the administrator role setting.
+    $form['admin_role']['user_admin_role']['#disabled'] = 'disabled';
+    // There should be no administrator role.
+    $form['admin_role']['user_admin_role']['#default_value'] = '';
+  }
+}

--- a/modules/custom/core/govcms_security/govcms_security.services.yml
+++ b/modules/custom/core/govcms_security/govcms_security.services.yml
@@ -1,0 +1,7 @@
+services:
+  govcms_security.CachedStorage:
+    class: Drupal\govcms_security\GovcmsCachedStorage
+    public: false
+    decorates: config.storage
+    decoration_priority: 10
+    arguments: ['@govcms_security.CachedStorage.inner']

--- a/modules/custom/core/govcms_security/src/GovcmsCachedStorage.php
+++ b/modules/custom/core/govcms_security/src/GovcmsCachedStorage.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Drupal\govcms_security;
+
+use Drupal\Core\Config\CachedStorage;
+use Drupal\Core\Config\StorageCacheInterface;
+use Drupal\Core\Config\StorageInterface;
+
+class GovcmsCachedStorage implements StorageInterface, StorageCacheInterface {
+
+  /**
+   * The inner service.
+   * 
+   * @var CachedStorage
+   */
+  protected $innerService;
+  
+  public function __construct(CachedStorage $inner) {
+    $this->innerService = $inner;
+    //parent::__construct($storage, $cache);
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function read($name) {    
+    $data = $this->innerService->read($name);
+    $config_categories = explode('.', $name);
+    
+    // Override configurations.
+    switch ($config_categories[0]) {
+      // User configurations
+      case 'user' :
+        if (isset($data['is_admin'])) {
+          // No role should be admin role.
+          $data['is_admin'] = false;
+        }
+        break;
+    }
+    
+    return $data;
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function readMultiple(array $names) {
+    $data_to_return = $this->innerService->readMultiple($names);
+    
+    foreach ($names as $name) {
+      $config_categories = explode('.', $name);
+      
+      // Override configurations.
+      switch ($config_categories[0]) {
+        case 'user' :
+          if (isset($data_to_return[$name]['is_admin'])) {
+            // No role should be admin role.
+            $data_to_return[$name]['is_admin'] = false;
+          }
+          break;
+      }
+    }
+    
+    return $data_to_return;
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function write($name, array $data) {
+    $config_categories = explode('.', $name);
+    // Override configurations.
+    switch ($config_categories[0]) {
+      case 'user':
+        if (isset($data['is_admin'])) {
+          // No role should be admin role.
+          $data['is_admin'] = false;
+        }
+        break;
+    }
+   
+    return $this->innerService->write($name, $data);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCollectionName() {
+    return $this->innerService->getCollectionName();
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteAll($prefix = '') {
+    return $this->innerService->deleteAll($prefix);
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function decode($raw) {
+    return $this->innerService->decode($raw);
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function delete($name) {
+    return $this->innerService->delete($name);
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function rename($name, $new_name) {
+    return $this->innerService->rename($name, $new_name);
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function resetListCache() {
+    return $this->innerService->resetListCache();
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function exists($name) {
+    return $this->innerService->exists($name);
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function getAllCollectionNames() {
+    return $this->innerService->getAllCollectionNames();
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function listAll($prefix = '') {
+    return $this->innerService->listAll($prefix);
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function createCollection($collection) {
+    return $this->innerService->createCollection($collection);
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function encode($data) {
+    return $this->innerService->encode($data);
+  }
+}
+


### PR DESCRIPTION
In a SaaS site, no user role is allowed to be configured as an admin role.

This PR delivers following new features:

- Update all existing user roles to reset the 'is_admin' flag as false.
- Lock down the configuration of Administrator role from the UI (/admin/config/people/accounts)
- Prevent a user role from being configured as the admin role by decorating the core services of config.storage.
