### PR TITLE
[GOVCMSD8-404]Fixes menu editing when scheduled_transitions is enabled.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,6 +167,9 @@
                 "The tfa.settings route should use the permission 'admin tfa settings' - https://www.drupal.org/project/tfa/issues/2943972": "https://www.drupal.org/files/issues/2943972-2.patch",
                 "Bad UX around 'required to setup TFA' concept and users who have skipped validation too many times - https://www.drupal.org/project/tfa/issues/2937336": "https://www.drupal.org/files/issues/2019-03-01/2937336-17.patch",
                 "Users' recovery codes exposed to admin users - https://www.drupal.org/project/tfa/issues/3075304": "https://www.drupal.org/files/issues/2019-08-16/tfa-3075304_2.patch"
+            },
+            "drupal/core": {
+                "Fix editing menu items when scheduled_transitions is enabled": "https://www.drupal.org/files/issues/2020-05-12/3016038-20.patch"
             }
         }
     },


### PR DESCRIPTION
Fixes #302 

At present if the `scheduled_transitions` module is enabled then attempts to edit menu links causes a WSOD.

This patch is the latest attached from [this issue](https://www.drupal.org/project/drupal/issues/3016038) and been tested with success on GovCMS8 1.x

The issue itself has been around since 2018, and currently targeting a fix in Drupal 9.1.x. Without this patch you must either choose between using GovCMS content types, or having a functional menu system as you cannot resolve it without removing the default GovCMS content types and uninstalling `scheduled_transitions`.