### PR TITLE
[GOVCMSD8-649] Update Entity Reference Display module from 1.2 to 1.3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "drupal/entity_browser": "2.1",
         "drupal/entity_class_formatter": "1.3",
         "drupal/entity_embed": "1.0",
-        "drupal/entity_reference_display": "1.2.0",
+        "drupal/entity_reference_display": "1.3",
         "drupal/entity_reference_revisions": "1.6",
         "drupal/environment_indicator": "3.5",
         "drupal/events_log_track": "1.1",


### PR DESCRIPTION
Update to Entity Reference Display to 1.3.
Note that it is for D9 compatibility and other non-breaking fixes.