### PR TITLE
[GOVCMSD8-648] Update Modifiers module from 1.3 to 1.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "drupal/menu_trail_by_path": "1.1",
         "drupal/metatag": "1.9",
         "drupal/minisite": "1.3",
-        "drupal/modifiers": "1.3",
+        "drupal/modifiers": "1.4",
         "drupal/module_filter": "3.1",
         "drupal/page_manager": "4.0-beta4",
         "drupal/panelizer": "4.1",


### PR DESCRIPTION
Update to Modifiers to 1.4.
Note that it is for D9 compatibility and other non-breaking fixes.