### PR TITLE
[GOVCMSD8-647] update core 8.9.1

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.8.8",
+        "drupal/core-recommended": "8.9.0",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.35",

--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.9.0",
+        "drupal/core-recommended": "8.9.1",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.35",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta2",
-        "drupal/core-recommended": "8.8.8",
+        "drupal/core-recommended": "8.9.0",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0-rc2",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta2",
-        "drupal/core-recommended": "8.9.0",
+        "drupal/core-recommended": "8.9.1",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0-rc2",


### PR DESCRIPTION
# Core 8.9.0
Release notes
This is a minor version (feature release) of Drupal 8 and is ready for use on production sites. Learn more about Drupal 8 and the Drupal 8 release cycle.

This minor release provides improvements without breaking backward compatibility (BC) for public APIs. There may be changes in internal APIs and experimental modules that require updates to contributed and custom modules and themes per Drupal core's backwards compatibility and experimental module policies.

Minor releases may include string changes and additions. Translators can review the latest translation status on localize.drupal.org.

Drupal 8.9 is the final minor release of the 8.x series. It is a long-term support (LTS) version, and will be supported until November 2021. It also provides the same public API as Drupal 9.0 aside from deprecated code and dependency changes. For more information on the Drupal 9 release, read the Drupal 9.0.0 release notes.

Drupal 8.9 is a good choice to update to first if you have an existing Drupal site, to ensure maximum compatibility and the smallest necessary changes for the Drupal 9 update.

If you are starting a new Drupal project, start with Drupal 9.0 for forward compatibility with later releases.

Regardless of which version you choose now, new features will only be added to upcoming Drupal 9 minor releases, so you should prepare your site for Drupal 9 this year in order to continue receiving the new features in Drupal 9.1 and 9.2.

# Core 8.9.1
Release notes
This release fixes security vulnerabilities. Sites are urged to upgrade immediately after reading the notes below and the security announcement:

- Drupal core - Critical - Cross-Site Request Forgery - SA-CORE-2020-004

- Drupal core - Critical - Arbitrary PHP code execution - SA-CORE-2020-005

- Drupal core - Less critical - Access bypass - SA-CORE-2020-006