### PR TITLE
Update paragraphs to the latest version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "drupal/page_manager": "4.0-beta4",
         "drupal/panelizer": "4.1",
         "drupal/panels": "4.4.0",
-        "drupal/paragraphs": "1.10",
+        "drupal/paragraphs": "1.12",
         "drupal/password_policy": "3.0-alpha4",
         "drupal/pathauto": "1.6.0",
         "drupal/permissions_by_term": "2.12",


### PR DESCRIPTION
There is an issue with how paragraphs 1.10 deals with revisions and can cause fatal errors preventing users from editing nodes in some circumstances.

This is outlined in: https://www.drupal.org/project/paragraphs/issues/3074114

Updating to the latest version of paragraphs prevents the issue as it adds defensive coding practices around the problem area.