### PR TITLE
[GOVCMSD8-515] update simple_sitemap module to 3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "drupal/seckit": "1.1",
         "drupal/shield": "1.2",
         "drupal/simple_oauth": "4.5",
-        "drupal/simple_sitemap": "3.4",
+        "drupal/simple_sitemap": "3.7",
         "drupal/swiftmailer": "1.0-beta2",
         "drupal/tfa":"1.0-alpha4",
         "drupal/token": "1.7",


### PR DESCRIPTION
# simple_sitemap 8.x-3.7
Release notes
Changes since 3.6
New features
None.

Bug fixes
#3126793: Notice: Undefined index in SimplesitemapSitemapsForm
#3127501: Warning if excluded_languages is not set
#3131672: No access to sitemap.xml from subdomains in multi-language site

Improvements
#3134984: License "GPL-2.0+" is a deprecated SPDX license identifier
#3135695: Replace assertions with more appropriate ones

API changes
None.