### PR TITLE
[GOVCMSD8-688] Update drupal core from 8.9.1 to 8.9.2

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.9.1",
+        "drupal/core-recommended": "8.9.2",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta2",
-        "drupal/core-recommended": "8.9.1",
+        "drupal/core-recommended": "8.9.2",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0-rc2",


### PR DESCRIPTION
# drupal 8.9.2
## Release notes
This is a patch (bugfix) release of Drupal 8 and is ready for use on production sites. Learn more about Drupal 8.

Drupal 8.9 is the final minor release of the 8.x series. It is a long-term support (LTS) version, and will receive security coverage until November 2021. It provides the same public API as Drupal 9.0 aside from deprecated code and dependency changes. (Learn more about Drupal 9.)

If you are upgrading to this release from 8.8.x, read the Drupal 8.9.0 release notes before you upgrade.