### PR TITLE
[GOVCMSD8-676] Update drupal/shield to 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
         "drupal/search_api_solr": "3.9",
         "drupal/search_api_attachments": "1.0-beta16",
         "drupal/seckit": "1.1",
-        "drupal/shield": "1.2",
+        "drupal/shield": "1.4",
         "drupal/simple_oauth": "4.5",
         "drupal/simple_sitemap": "3.4",
         "drupal/swiftmailer": "1.0-beta2",


### PR DESCRIPTION
# shield 8.x-1.4
## Release notes
This release changes the minimum supported version from 8.6 to 8.7.7 and introduces support for Drupal 9.

To see other changes that occurred since version 1.2, view the 1.3 release notes:
https://www.drupal.org/project/shield/releases/8.x-1.3