### PR TITLE
[GOVCMSD8-680] Update drupal/pathauto to 1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "drupal/panels": "4.4.0",
         "drupal/paragraphs": "1.12",
         "drupal/password_policy": "3.0-beta1",
-        "drupal/pathauto": "1.6.0",
+        "drupal/pathauto": "1.8.0",
         "drupal/permissions_by_term": "2.12",
         "drupal/real_aes": "2.2",
         "drupal/recaptcha": "2.4",


### PR DESCRIPTION
# pathauto 8.x-1.8
## Release notes
Drupal 9 compatibility and bugfixes. Requires Drupal 8.8 and fixes a problem in 8.x-1.7 to allow updating from Drupal 8.7.