### PR TITLE
[GOVCMSD8-681] Update drupal/menu_block to 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "drupal/login_security": "1.5",
         "drupal/media_entity_file_replace": "1.0-beta2",
         "drupal/memcache": "2.0",
-        "drupal/menu_block": "1.5",
+        "drupal/menu_block": "1.6",
         "drupal/menu_trail_by_path": "1.1",
         "drupal/metatag": "1.9",
         "drupal/minisite": "1.3",


### PR DESCRIPTION
# menu_block 8.x-1.6
## Release notes
Changes since 8.x-1.5:

#3129882 by Suresh Prabhu Parkala: Fix PHPCS error
#2968049 by joelpittet, nkoporec, vdenis, alexpott, Berdir, gapple, dww, Aston Victor, andypost, Wim Leers, idebr: Dependency Injection issue
#3115436 by dww, jungle, mattbloomfield, Kristen Pol: Use proper dependency injection and protect menu_block from changes to the SystemMenuBlock constructor
#3042653 by matsbla, jenlampton: Drupal 9 Deprecated Code Report
#3118828 by dww: MenuBlockTest should define defaultTheme
#3038396 by JeroenT, dww: Add automated tests
#3086171 by dww: Add @file doc block to menu_block.module
#3022011 by JeroenT, idebr: Implement config schema for block.settings.menu_block.*.{follow, follow_parent}
#2756675 by Gertjan.k, pookmish, Tom.Camp, Eyal Shalev, nod_, rutiolma, adammalone, johnny5th, byrond, drclaw, manuel.adan, stefan.r, polynya, sherakama, rmccreary, mithenks: Add option to make the starting level follow the active menu item
#2981885 by jeroendegloire, justcaldwell: No 'Edit Menu' functionality in Settings Tray
#2983880 by chipway: Apply new {project}:{module} format for dependencies in info.yml
#2932048 by RajeevK, pingers, harsha012, Prashant.c, Maheshwaran.j, joelpittet, Dinesh18: Config schema mismatch for expand(ed)