### PR TITLE
[GOVCMSD8-682] Update drupal/focal_point to 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "drupal/facets": "1.3",
         "drupal/features": "3.8",
         "drupal/field_group": "3.1",
-        "drupal/focal_point": "1.2",
+        "drupal/focal_point": "1.4",
         "drupal/ga_login": "1.0-alpha4",
         "drupal/google_analytics": "3.0",
         "drupal/govcms_dlm": "1.3",


### PR DESCRIPTION
# focal_point 8.x-1.4
## Release notes
#3102633: Keep the original focal_point value to be able to use it during hooks by lebster: Keep the original focal_point value to be able to use it during hooks (4 hours ago)
#3124690: Missing the FormStateInterface use in focal_point.module by xavier.masson: Missing the FormStateInterface use in focal_point.module (4 hours ago)
#3126130: FocalPointImageWidget::process() called twice by quicksketch: FocalPointImageWidget::process() called twice (4 hours ago)