### PR TITLE
[GOVCMSD8-669] Update drupal/adminimal_admin_toolbar to 1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.4",
         "drupal/admin_toolbar": "2.0",
-        "drupal/adminimal_admin_toolbar": "1.9.0",
+        "drupal/adminimal_admin_toolbar": "1.11.0",
         "drupal/adminimal_theme": "1.4",
         "drupal/chosen": "2.6.0",
         "drupal/components": "1.0.0",


### PR DESCRIPTION
# adminimal_admin_toolbar 8.x-1.11
## Release notes
Drupal 9 Readiness added
Issue #3090873 by Lilit_Ghazaryan, ducktape: Button to put the menu in horizontal mode is not working when the Manage menu is displayed in full
Issue #3094703 by robertoperuzzo: Add core_version_requirement
Issue #3129273 by Suresh Prabhu Parkala: Fix PHPCS errors
