### PR TITLE
[GOVCMSD8-704] update search_api_solr 4.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
         "drupal/robotstxt": "1.4",
         "drupal/scheduled_transitions": "1.0.0-rc1",
         "drupal/search_api": "1.16",
-        "drupal/search_api_solr": "3.9",
+        "drupal/search_api_solr": "4.1.4",
         "drupal/search_api_attachments": "1.0-beta16",
         "drupal/seckit": "1.1",
         "drupal/shield": "1.2",
@@ -140,7 +140,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/admin_toolbar": {
-                "Vertical tab display bug after page reload - https://www.drupal.org/project/admin_toolbar/issues/3154104": "https://www.drupal.org/files/issues/2020-06-23/admin_toolbar-vertical-display-fix-3154104-2-D8.patch" 
+                "Vertical tab display bug after page reload - https://www.drupal.org/project/admin_toolbar/issues/3154104": "https://www.drupal.org/files/issues/2020-06-23/admin_toolbar-vertical-display-fix-3154104-2-D8.patch"
             },
             "drupal/config_ignore": {
                 "Offset error within IgnoreFilter::activeReadMultiple() - https://www.drupal.org/project/config_ignore/issues/2972302": "https://www.drupal.org/files/issues/2018-07-31/offset-error-within-2972302-13.patch"

--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/admin_toolbar": {
-                "Vertical tab display bug after page reload - https://www.drupal.org/project/admin_toolbar/issues/3154104": "https://www.drupal.org/files/issues/2020-06-23/admin_toolbar-vertical-display-fix-3154104-2-D8.patch"
+                "Vertical tab display bug after page reload - https://www.drupal.org/project/admin_toolbar/issues/3154104": "https://www.drupal.org/files/issues/2020-06-23/admin_toolbar-vertical-display-fix-3154104-2-D8.patch" 
             },
             "drupal/config_ignore": {
                 "Offset error within IgnoreFilter::activeReadMultiple() - https://www.drupal.org/project/config_ignore/issues/2972302": "https://www.drupal.org/files/issues/2018-07-31/offset-error-within-2972302-13.patch"


### PR DESCRIPTION
# search_api_solr 4.1.4
## Release notes
Search API Solr 4.1.x is the unified release that supports Drupal 8 and 9 and a wide range of Solr versions.

The big changes in 4.x compared to 3.x:

semantic versioning
compatible to Drupal 8.8, 8.9 and 9.x
We upgraded to solarium 6.0 and therefore require at least PHP 7.2
basic support for older Solr versions between 4.5 and 5.5 via the new search_api_solr_legacy sub-module
jump-start Solr config-sets you could simply copy and deploy on you're Solr sever to create a core or a collection
Like Search API Solr Search 8.x-3.x, it supports upgrade paths from any previous 8.x version including Search API Solr Multilingual 8.x-1.x!

BTW there's a new user contributed documentation: https://www.drupal.org/docs/8/modules/search-api-solr

The big changes in 3.x compared to 2.x:

We collapsed the features of the Standard Backend, both Multilingual Backends and the "Any Schema" Backend into a one new unified Solr Backend. There's a migration path :-)
Mulitisite is back! Select "Clone for Multisite" in an Index' operations, save the Clone Form, export the cloned index config (and probably the server config), deploy the config to a different site, configure a search View as usual, enjoy! ;-)
Spellchecking is now configurable like Suggesters. Use the standard filed configuration to decide which fields should feed the spellcheck catalog
We now distinguish between NGram and EdgeNGram. Both field types are fully configurable via Drupal config files.
Solr 7/8 compatible implementation of index time boosting of terms and documents
Configurable MoreLikeThis parameters per index
Support for Solr Cloud exclusive features
The big changes in 3.x compared to 1.x:

The module doesn't include ready to use Solr config-sets anymore! These were too limited for the changes mentioned above. In 3.x the config-sets will be "generated" individually for your site. See
https://git.drupalcode.org/project/search_api_solr/blob/8.x-3.x/solr-con...
https://git.drupalcode.org/project/search_api_solr/blob/8.x-3.x/INSTALL.md
https://www.drupal.org/docs/8/modules/search-api-solr/search-api-solr-ho...
Native support for Solr Cloud
Multingual
Important: Since solarium 5.0 supports Solr v2 API, the connector settings need to be adjusted! The "path" must not end with "/solr" but "/" without "solr" because that is the v1 API endpoint!
Your existing configs will be adjusted automatically via an update hook implementation. But if you've overwritten the connection settings (for example in settings.php) you must adjust the path by yourself!

Important: You need to update your Solr config files if you update from any previous version! After deploying the config set to your Solr server(s) you need to re-index your content!

Important: You might need to adjust the solrcore.properties file to your needs. If you get errors about missing classes you should adjust the solr.install.dir.

PHP 7.2 or newer required!
Due to the requirements of the libraries we use we can't support PHP 5, PHP 7.0 or PHP 7.1 anymore! These versions reached EOL anyway.

The recommended way to install this module properly is the usage of composer!
To install the module including its dependencies simply change into your drupal directory and run composer require drupal/search_api_solr:^4.1.
But if you just download the module it won't work because the required external libraries are not part of this package!

The Drupal 8 symfony/event-dispatcher issue!
See #3085196: How to upgrade to solarium 5.1.x, 5.2.x or 6.0.x for details. But with the Search API Solr 4.1.0 release we solved that issue! So it doesn't exist anymore for new installations.
If you applied one of the workarounds before, don't forget to revert them!
Drupal 8 users should for example update like this to revert to the original event-dispatcher:
composer require symfony/event-dispatcher:~3.4.0 solarium/solarium:^6.0 search_api_solr:^4.1

Upgrade path for Search API Multilingual Solr Search 8.x-1.x
You should NOT upgrade to 8.x-2.x or 8.x-3.x first! Just directly upgrade to 4.x.

Changes since 4.1.3
#3146655: Throw exception if config.zip is not usable by cristiroma, mkalkbrenner, mandclu
#3157009: Missing solrconfig_index.xml by mkalkbrenner, sah62
Changes since 4.1.2
#3127004: Test failures with PHP 7.4 by mkalkbrenner
#3155397: Don't complain about modified schema if jump-start-config is used by mkalkbrenner
#3154019: There are some language-specific field types missing in schema of Solr server localhost: pt-pt. by jcnventura, mkalkbrenner
#3152575: Unable to find the wrapper "temporary" in tests by mkalkbrenner
#3155395: Devel dumper fails on large responses by mkalkbrenner
#3155070: drupal/devel 3.x doesn't exist anymore by jcnventura, mkalkbrenner
#3146655: Throw exception if config.zip is not usable by mkalkbrenner
Changes since 4.1.1
#3150197: BackendTrait for Suggesters fails on logging Exceptions by suzymasri, mkalkbrenner, kfritsche
#3118978: Error 500 thrown by Solr server on admin/reports/status by Sam152, kreatIL, mkalkbrenner
#3153247: Replace assertions involving calls to isset() with assertArrayHasKey()/assertArrayNotHasKey by gena.io, mkalkbrenner
#3152575: Unable to find the wrapper "temporary" in tests by mkalkbrenner
#2924132: Port solr_devel functionality to Search API Solr (Part 2) by janusman, mkalkbrenner, DigitalCatalyst
Changes since 4.1.0
#3150214: Fatal error: Declaration of Drupal\search_api_solr\Solarium\EventDispatcher\Psr14Bridge::dispatch by mkalkbrenner
Changes since 4.0.1
#3146619: Require solarium 6 to solve core/symfony compatibility event dispatcher issues by mkalkbrenner
#3131198: View sort by relevance alters results by mariusdiacu, mkalkbrenner
#3145656: SolrFieldTypeForm fatals if the text fields property is empty by andrewbelcher, mkalkbrenner
#3144903: Invalid Date String Exception when highlighting by mkalkbrenner, julia_schwarz
Changes since 4.0.0
#3137654: New path for ArrayUtils forgot to be changed in the .module by Fabsgugu, geerlingguy, jonathan_hunt, mkalkbrenner
#3135367: Run daily tests on github by o-msh, mkalkbrenner
Changes since 4.0.0-beta2
#3136510: Incorrect notice language specific field types missing by mkalkbrenner, paulvb
#3135367: Run daily tests on github by mkalkbrenner
Changes since 4.0.0-beta1
#3133881: Update README.md by solideogloria, mkalkbrenner
#3134522: Collapse README.md and INSTALL.md by mkalkbrenner
#3134482: Only test Solr 4 on travis by mkalkbrenner
#3070455: Provide jump-start Solr config-sets by mkalkbrenner
#3132722: Error: Unsupported operand types in search_api_solr_legacy_form_search_api_server_form_alter() by mkalkbrenner, jhedstrom
#3109911: Autocomplete suggestions fail for large requests by recrit, mkalkbrenner
#3066092: Delete nested documents when deleting parent by bucefal91, mkalkbrenner, rp7
#3130331: Basic Auth is covered by solarium already, remove obsolete code by mkalkbrenner
#3124893: Test against solarium 5.2 and 6.0 by mkalkbrenner
#3128048: Update depedency and support multiple versions of them by mkalkbrenner, japerry
Changes since 4.0.0-alpha1
#3127958: SEARCH_API_SOLR_MIN_SCHEMA_VERSION needs to be adjusted to semantic versioning by mkalkbrenner
#3127886: Forcing Solr 4 must set minimum version to 4.5.0 instead of 4.0.0 by mkalkbrenner
Changes since 8.x-3.9
#3127078: Using assertContains() with string haystacks is deprecated by mkalkbrenner
#3126833: provide search_api_solr_legacy as transition to Drupal 9 for Solr 4 and 5 users by mkalkbrenner
#3106867: Don't show Solr specific index options if backend isn't a Solr backend by batkor, mkalkbrenner
#3124436: get prepared for solarium 5.2 and 6.0 by mkalkbrenner
#3124428: raise core dpendency from 8.7.7 to 8.8 by mkalkbrenner
#3122937: Test against Solr 8.5.0 by mkalkbrenner
#3113473: Concat syntax fix by gnunes, mkalkbrenner
#3113079: don't verify the Solr config set in use if skip_schema_check is set. by mkalkbrenner
#3109599: Solr endpoint unreachable or returned unexpected response code "0" when indexing by mkalkbrenner
#3096210: Improve french solr_field_type by B2F, mkalkbrenner, gonssal, SylvainM, DeFr
#3104257: ElisionFilterFactory issue on text_fr by B2F, mkalkbrenner