### PR TITLE
[GOVCMSD8-705] update drupal/core 8.9.3

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.9.2",
+        "drupal/core-recommended": "8.9.3",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",

--- a/composer.json
+++ b/composer.json
@@ -150,8 +150,7 @@
               "Replace deprecated AllowedTagsXssTrait": "https://www.drupal.org/files/issues/2020-04-17/3128413-10.patch"
             },
             "drupal/core": {
-                "Private file download returns access denied, when file attached to revision other than current - https://www.drupal.org/project/drupal/issues/1452100#comment-13653216": "https://www.drupal.org/files/issues/2020-05-29/1452100-file-access-97.patch",
-                "Unrecognised entity operation passed to Menu Link Content throws exceptions - https://www.drupal.org/project/drupal/issues/3016038": "https://www.drupal.org/files/issues/2020-07-23/3016038-32.patch"
+                "Private file download returns access denied, when file attached to revision other than current - https://www.drupal.org/project/drupal/issues/1452100#comment-13653216": "https://www.drupal.org/files/issues/2020-05-29/1452100-file-access-97.patch"
             },
             "drupal/events_log_track": {
                 "Events Log Track breaks Entity Browser #5 - https://www.drupal.org/project/events_log_track/issues/2934036": "https://www.drupal.org/files/issues/2018-04-19/2934036-check_empty_submit-5.patch",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta2",
-        "drupal/core-recommended": "8.9.2",
+        "drupal/core-recommended": "8.9.3",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0-rc2",


### PR DESCRIPTION
# drupal 8.9.3
Release notes
This is a patch (bugfix) release of Drupal 8 and is ready for use on production sites. Learn more about Drupal 8.

Drupal 8.9 is the final minor release of the 8.x series. It is a long-term support (LTS) version, and will receive security coverage until November 2021. It provides the same public API as Drupal 9.0 aside from deprecated code and dependency changes. (Learn more about Drupal 9.)

If you are upgrading to this release from 8.8.x, read the Drupal 8.9.0 release notes before you upgrade.

Known issues
Search the issue queue for known issues.

All changes since Drupal 8.9.2
Issue #3136762 by dww, codersukanta, webchick, larowlan: Update.php includes link to 'Put site into maintenance mode' for users without permission to use it
Issue #3163162 by quietone: Fix error in d7 fixture field_config_instance table
Issue #3151096 by dww, jungle: Replace use of whitelist in \Drupal\Core\Utility\ProjectInfo
Issue #3151098 by rik-dev, dww: Replace use of whitelist/blacklist in Big Pipe module
Issue #3160031 by quietone, alexpott, jungle, longwave, jameszhang023: Fix 18 spelling errors for migrate specific terms
Issue #3074595 by Lendude, ravi.shankar, sime, jian he, Kristen Pol, longwave: var_export only returns if the second parameter set to TRUE
Issue #3156879 by alexpott, Krzysztof Domański: \Drupal\Component\Utility\Bytes::toInt() - ensure $size is a number type
Issue #2875807 by idebr, Hardik_Patel_12, Kristen Pol, larowlan: [backport] Drupal::l() / Link::fromTextAndUrl $text documented as string, actually accepts string|array|\Drupal\Component\Render\MarkupInterface
Issue #3139414 by cburschka, mohrerao, pavnish, jungle, ravi.shankar, mondrake, daffie, sja112: [backport] Replace usages of deprecated AssertLegacyTrait::assert(No)Link()
Issue #3155110 by maacl, Mykola Veryha: Update CKEditor to version 4.14.1
Issue #3089495 by andrewmacpherson, Kristen Pol: BooleanCheckboxWidget settings summary is not fully translatable
Issue #3162479 by tedbow, Kristen Pol: Incorrect Drupal\Composer\VendorHardening namespace is used instead of Drupal\Composer\Plugin\VendorHardening
Issue #3142749 by munish.kumar, shaktik, pavnish, sja112, ravi.shankar, Lal_, mondrake, daffie, xjm: AssertLegacyTrait::assertPattern() calls in functional tests still have a message passed in
Issue #3138766 by mohrerao, longwave, sja112, jameszhang023, Lal_, ravi.shankar, jungle, xjm: Fix "Don't" relevant typos in core
Issue #3092551 by amateescu, poojakural, pankaj.singh, priyanka.sahni, shaal, nod_, lauriii: Unclickable area to switch to a workspace
Issue #3153264 by siddhant.bhosale, Hardik_Patel_12, longwave: Remove uses of t() in clickViewsOperationLink(), helperButtonHasLabel() and optionExists() calls
Issue #3161301 by jungle, bbrala, alexpott: Fix typo "existant" in Core
Issue #3158270 by Hardik_Patel_12, siddhant.bhosale, paulocs: Unused local variables in SelectComplexTest file
Issue #3158589 by bhushan.nagaonkar, brittany.huntzberry, ankithashetty, cilefen, alexpott, davidhernandez, nijolawrence: Improve comment in default.settings.php
Issue #3156040 by Hardik_Patel_12, kiamlaluno, siddhant.bhosale, paulocs: Avoid initializing a local variable to an empty array before adding items to that array
Issue #2994319 by Ramya Balasubramanian, mohrerao, virajrajankar, benjamindamron, hardikpandya, kalyansamanta, jhodgdon, msankhala, jungle, kkalaskar, dhirendra.mishra, joachim, longwave, amateescu, mradcliffe, alexpott, jcnventura: EntityAutocomplete form element has no docs on how to use it
Issue #3161199 by lauriii, bnjmnm: Remove $no_operator = TRUE from Views BooleanOperator
Issue #3123120 by mondrake, mrinalini9, ridhimaabrol24, longwave, catch: [backport] Properly deprecate AssertLegacyTrait::pass
Issue #3161300 by jungle, TR, Hardik_Patel_12, Chris Burge, longwave, Kristen Pol: Improve test coverage of \Drupal\Tests\layout_builder\Unit\SectionTest::testUnsetThirdPartySetting()
Issue #3158276 by Hardik_Patel_12, kiamlaluno, paulocs: Remove local unused variables from RequestFormatRouteFilterTest.php file
Issue #3159982 by nuklive, ultrabob, J2, billywardrop, antojose, daffie, mradcliffe, mcdruid, jungle: AS keyword should be capitalised in SQL queries
Issue #3158281 by paulocs, kiamlaluno, Hardik_Patel_12, greg.1.anderson: Unused local variables from ScaffoldTest.php file
Issue #2348203 by agentrickard, govind.maloo, mohit_aghera, dagmar, init90, Berdir, alexpott, chx, catch, xjm: hook_node_access() no longer fires for the 'create' operation
Issue #3156345 by jungle, S_Bhandari, Hardik_Patel_12, kiamlaluno, alexpott: Remove Unused variable $method_definitions from PathProcessorTest.php file
Issue #3117396 by penyaskito, Berdir: Pathauto requirements confusing message when running -dev
Issue #3159739 by jungle, Beakerboy, daffie: Avoid directly comparing string to blob in EntityDisplayTest
Issue #3160020 by jungle, ravi.shankar, alexpott, ultrabob: Fix typos "iids, twoa, twob, roota, rootb, parentc" by refactoring
Issue #3122051 by phenaproxima, andrewmacpherson, Kristen Pol: Name field is always shown on media library form display when adding a new remote video media type
Issue #3016038 by dpi, acbramley, jibran, dww, phenaproxima, jungle, Mingsong: Unrecognised entity operation passed to Menu Link Content throws exceptions
Issue #3159730 by alexpott, greg.1.anderson: Update composer/installers in root composer.json and lock so we can use Composer 2
Issue #3160124 by jungle, jameszhang023, alexpott: Fix "wiget, escapeable, PHPunit" typos in Core
Issue #3155796 by Hardik_Patel_12, kiamlaluno: Remove Unused variable $node_storage from NodeRevisionsUiBypassAccessTest.php file
Issue #3155462 by andrewmacpherson: Remove landmark region role from Powered-by-Drupal block
Issue #3160169 by jameszhang023: Unused variable $a in \Drupal axonomy\Plugin\Validation\Constraint\TaxonomyTermHierarchyConstraintValidator::validate()
Issue #2728507 by Lendude, Kristen Pol, pameeela: Not selecting an entity type on Config import single leads to a fatal error
Issue #3157919 by ultrabob, Hardik_Patel_12, shaktik, nijolawrence, alexpott, lauriii, Berdir, kiamlaluno: Remove unused variable $node from link module
Issue #3156070 by Hardik_Patel_12, kiamlaluno: Unused local variables from ConfigSchemaTest file
Issue #3085751 by alexpott, Deepak Goyal, rpayanm, longwave, catch, volkerk, kristiaanvandeneynde, dww: [backport] Setter injection arguments are not checked for unmet dependencies
Issue #3159528 by jameszhang023, jungle, longwave: Fix typos: "exeption|gaurd|ouptut|withut|defintion" in core
Issue #3159531 by jameszhang023, ipumpkin, jungle, longwave: Fix typos: "attibute|uneccesarilly|colletion|constucts|worklow" in core
Issue #3089745 by aleevas, larowlan, dipakmdhrm, pameeela, seycom, joey-santiago, xjm, seanB, rooby: Add focus behaviour for media widget with max elements
Issue #3091309 by tim.plunkett, godotislate, paulocs, thursday_bw, alexpott, TwiiK: Broken context-aware block plugins throw an unexpected exception
Issue #3138749 by jackniu, dww, jungle: Fix "cache" related typos
Issue #3155563 by mcdruid, mrinalini9, Hardik_Patel_12, mondrake, daffie: select query should quote aliases which are reserved words in MySQL
Issue #3039991 by amateescu, lpeabody, bgreco, plach: Base field purging is not handling translatable fields correctly
Issue #3153869 by jungle, xjm, NickDickinsonWilde, longwave: [backport] Remove leftover of wikimedia/composer-merge-plugin
Issue #2912244 by quietone, heddn, FMB: Document MigrateIdMapInterface
Issue #3159382 by Beakerboy: Sort order not specified in view test_view_fieldapi, but results must be ordered by nid
Issue #3151360 by quietone, benjifisher, ToneLoc: Improve description for file paths on the CredentialFrom
Issue #3158292 by Hardik_Patel_12, kiamlaluno: Remove unused variables from FormAjaxResponseBuilderTest.php file
Issue #3159102 by Niklan: Documentation for \Drupal\serialization\RegisterEntityResolversCompilerPass is incorrect
Issue #2942569 hotfix: Sorting nested properties of config entity queries does not work
Issue #2855068 hotfix: Can't create comments when comment is a base field
Issue #3156882 by alexpott, johnwebdev, adityasingh, pfrenssen: \Drupal\Core\Render\Element\StatusReport::preRenderGroupRequirements() and \Drupal\user\PermissionHandler::sortPermissions() sorts return bools
Issue #2942569 by seanB, idebr, amateescu, kristiaanvandeneynde: Sorting nested properties of config entity queries does not work
Issue #3126063 by quietone, Wim Leers, DamienMcKenna, benjifisher, alexpott, heddn: Harden SubProcess process plugin
Issue #3040361 by Sam152, jungle, Dylan Donkersgoed, jibran: Moderation state views filter only works on base table entity
Issue #3156883 by alexpott, longwave: \Drupal\Core\Url ensure fragment is not an empty string
Issue #3155765 by naresh_bavaskar: Fixing minor typo in path alias module test files
Issue #3157369 by shaktik, Lendude, alexpott: Use unused variable $filters from DateTimeSchemaTest
Issue #3157933 by S_Bhandari: Remove Unused variables from Views UI module
Issue #2801929 by Lendude, ridhimaabrol24, Sutharsan, gilles.koffmann, geek-merlin, dawehner: View loses records after adding comment count field
Issue #3112916 by Sam152, ocelotkevin, corneboele, jantoine, yovince, bkosborne: Content Moderation views should join on entity ID
Issue #3154914 by ju.vanderw: Fix grammar usage of singular/plural
Issue #3156123 by andypost: Fix MissingContentEvent see reference
Issue #2988960 by tstoeckler, Kristen Pol: Testing profile's locale.settings config override is not up-to-date
Issue #3157462 by Hardik_Patel_12, sd9121: Fixing comment error in viewAddForm file
Issue #3154858 by kristiaanvandeneynde: Drupal\Core\Config\Entity\Query\Condition::notExists() does not work when parent property is also missing
Issue #3151364 by Charlie ChX Negyesi, amateescu, alexpott, jhodgdon: diacritics are not removed from ǢǣǼǽǮǯ
Issue #3151975 by daffie, narendra.rajwar27: Replace the database query with an entity query in NodeRevisionsTest
Issue #3153791 by Wim Leers, quietone: Add comment field for 'et' content type to d7 fixture
Issue #3146016 by Beakerboy, daffie: Sort order not specified in view test_node_revision_uid, but results asserted to be in a specific order
Revert "Issue #3146016 by Beakerboy, daffie: Sort order not specified in view test_node_revision_uid, but results asserted to be in a specific order"
Issue #3146016 by Beakerboy, daffie: Sort order not specified in view test_node_revision_uid, but results asserted to be in a specific order
Issue #3154125 by Patrick R., kevinvhengst: Return type of ContentEntityFormInterface::validateForm() seems to be wrong
Issue #3155463 by longwave, quietone, jungle: Fix spelling error in Drupalilter\Plugin\migrate\process\FilterID::getSourceFilterType()
Issue #3153565 by vijaycs85: Update instances of Drupal\Core\Pager\RequestPagerInterface with Drupal\Core\Pager\PagerParametersInterface
Issue #2521782 by paulmckibben, mparker17, MerryHamster, swentel, yogeshmpawar, caspervoogt, Nikolay Borisov, maebug, jkuma, Saviktor, Wim Leers, catch: HTML head has alternate hreflang links to unpublished translations
Issue #3142893 by hchonov, Raunak.singh, kishor_kolekar, alexpott, tstoeckler, catch, kfritsche, johnwebdev: Memory leak - typed data prototypes for field items are not re-used like intended
Issue #2855068 by jian he, larowlan, andypost, mrinalini9, Jody Lynn, himanshu-dixit, LaravZ, jurgenhaas: Can't create comments when comment is a base field
Issue #3089961 by tim.plunkett, Deepak Goyal, Lal_, ravi.shankar, tedbow: assertOffCanvasFormAfterWait() doesn't check for the correct form ID
Issue #2848367 by mlncn, jp.stacey, kunalkursija: Render API overview example of placeholders either incorrect or misleading