### PR TITLE
[GOVCMSD8-679] update real_aes 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "drupal/password_policy": "3.0-beta1",
         "drupal/pathauto": "1.8.0",
         "drupal/permissions_by_term": "2.12",
-        "drupal/real_aes": "2.2",
+        "drupal/real_aes": "2.3",
         "drupal/recaptcha": "2.4",
         "drupal/redirect": "1.3",
         "drupal/restui": "1.16.0",


### PR DESCRIPTION
# real_aes 8.x-2.3
## Release notes
Contributors (2)
markdorison, malcolm_p

Changelog
Issues: 2 issues resolved.

Changes since 8.x-2.2:

Bug
#3043285 by malcolm_p: Encrypt RC2 requires can_decrypt plugin property
Task
#3129139 by markdorison: Drupal 9 compatibility with core_version_requirement