### PR TITLE
[GOVCMSD8-466] update consumers 1.11

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -4,7 +4,7 @@ services:
     image: tugboatqa/mysql:5
 
   app:
-    image: tugboatqa/php:7.3-apache
+    image: tugboatqa/php:7.4-apache
     # Set this as the default service. This does a few things
     #   1. Clones the git repository into the service container
     #   2. Exposes port 80 to the Tugboat HTTP proxy

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/config_perms": "1.2.0",
         "drupal/config_split": "1.4",
         "drupal/config_update": "1.6",
-        "drupal/consumers": "1.9",
+        "drupal/consumers": "1.11",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta2",
         "drupal/core-recommended": "8.9.6",


### PR DESCRIPTION
# consumers 8.x-1.11
## Release notes
This release adds full support for Drupal 9 by removing deprecated code and fixing issues with update path tests. You should now be able to install and use the Consumers module with a Drupal 9 site using `composer require drupal/consumers`.

#3115996: UpdatePathTest breaks with Drupal 9
#3116338: Drupal 9 Compatibility

In addition, it fixes an issue with the Plugin ID of the widget used to show the image field on the Consumer entity form.

#3105435: Invalid widget plugin ID is used on the consumer's field "image"

Thank you to everyone who helped.