### PR TITLE
[GOVCMSD8-479] update entity_embed 1.1

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -4,7 +4,7 @@ services:
     image: tugboatqa/mysql:5
 
   app:
-    image: tugboatqa/php:7.3-apache
+    image: tugboatqa/php:7.4-apache
     # Set this as the default service. This does a few things
     #   1. Clones the git repository into the service container
     #   2. Exposes port 80 to the Tugboat HTTP proxy

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "drupal/dynamic_entity_reference": "1.7.0",
         "drupal/entity_browser": "2.1",
         "drupal/entity_class_formatter": "1.3",
-        "drupal/entity_embed": "1.0",
+        "drupal/entity_embed": "1.1",
         "drupal/entity_reference_display": "1.3",
         "drupal/entity_reference_revisions": "1.6",
         "drupal/environment_indicator": "3.5",


### PR DESCRIPTION
# entity_embed 8.x-1.1
## Release notes
This release adds support for Drupal 9, and drops support for Drupal 8.7. The following issues were fixed:

#3109693: Fix tests on Drupal 9 and drop support for 8.7
#3111393: EntityEmbedTwigExtension uses deprecated entity.manager in its service definition
#3087572: Drupal 9 Deprecated Code report
#3108151: Fix broken tests on Drupal 8.8 and up
#3074061: Update CKEditor plugin to be compatible with Drupal 8.8
