### PR TITLE
[GOVCMSD8-487] update google_analytics 8.x-3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "drupal/field_group": "3.1",
         "drupal/focal_point": "1.4",
         "drupal/ga_login": "1.0-alpha4",
-        "drupal/google_analytics": "3.0",
+        "drupal/google_analytics": "3.1",
         "drupal/govcms_dlm": "1.3",
         "drupal/govcms8_ui": "1.0.0-alpha1",
         "drupal/govcms8_uikit_starter": "1.0-alpha2",


### PR DESCRIPTION
# google_analytics 8.x-3.1
## Release notes
This is mostly a bugfix release designed to work with Drupal 9, it also requires Drupal 8.8.6+.

Other issues fixed since 8.x-3.0:

Issue #3145668 by fgm: Incorrect service requested causes WSOD on Drupal 9
Issue #3145431 by japerry: Remove PHP Filter test and deprecate use of PHP Filter.
Issue #3139329 by dharizza, japerry, Gnanagowthaman sankar, sleitner: Drupal 9 Readiness.
Issue #3072027 by thalles: Add doc comments on
GoogleAnalyticsAdminSettingsForm
Issue #3007939 by alonaoneill, thalles, dhirendra.mishra, hass: README
configs and useful links
Issue #3066029 by au_dave: Allow optimize_id as valid configuration
parameter
Place paths in code view
Issue #3007939 by alonaoneill, dhirendra.mishra: README configs and
useful links
Issue #3057599 by thalles: Use StringTranslationTrait on Tests
Issue #3048523 by thalles: Replace ModuleHandler by
ModuleHandlerInterface
Issue #3042572 by ChaseOnTheWeb: Drupal 9 Deprecated Code Report
Add values to array
Make the default install more user and GDPR friendly
