### PR TITLE
[GOVCMSD8-495] update memcache 8.x-2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "drupal/linkit": "5.0-beta9",
         "drupal/login_security": "1.5",
         "drupal/media_entity_file_replace": "1.0-beta2",
-        "drupal/memcache": "2.0",
+        "drupal/memcache": "2.2",
         "drupal/menu_block": "1.6",
         "drupal/menu_trail_by_path": "1.1",
         "drupal/metatag": "1.9",


### PR DESCRIPTION
# memcache 8.x-2.2
## Release notes
This is an iterative release for memcache, with the biggest change adding transaction support and debugging.

All changes since 2.1:

Issue #435694 by Jeremy, markpavlitski, rbayliss, Elijah Lynn, glennpratt, markus_petrux, pdrake, achton, japerry, arantxag, solution33r, wwhurley, rhristov: >1M data writes incompatible with memcached (memcached -I 32M -m32)
Issue #2996615 by m4olivei, wim leers, Fabianx: Transaction support for cache (tags) invalidation
Minor Coding Standards for the admin settings module.
Issue #3002490 by Beakerboy: Drupal\Tests\memcache\Kernel\MemcacheBackendTest fails
Issue #3144383 by japerry, joachim: 'htmlspecialchars() expects parameter 1 to be string' warning on Statistics page due to incorrect use of t()
Issue #3002505 by Beakerboy, idebr: Implement configuration schema for memcache_admin.settings
# memcache 8.x-2.1
## Release notes
This is the first stable release of memcache for Drupal 9. It is compatible with both Drupal 8.x and 9.x

Most of the changes are to address deprecations. It should install without needing to run updb or clear cache.

All changes:

Issue #3133565 by ShaunLaws: PHP Notice causing memcache statistics page to fail
Issue #3038440 by hctom, Dane Powell, jwilson3: Cache rebuild errors caused by suggested PSR4 include
Fix capitalization for the HtmlResponse class.
Issue #3042707 by jcnventura, nikolas.tatianenko, jhuhta, Sergiu Stici: Drupal 9 Deprecated Code Report (Messenger)