### PR TITLE
[GOVCMSD8-500] update panelizer 8.x-4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "drupal/modifiers": "1.4",
         "drupal/module_filter": "3.1",
         "drupal/page_manager": "4.0-beta4",
-        "drupal/panelizer": "4.1",
+        "drupal/panelizer": "4.4",
         "drupal/panels": "4.4.0",
         "drupal/paragraphs": "1.12",
         "drupal/password_policy": "3.0-beta1",


### PR DESCRIPTION
# panelizer 8.x-4.4
## Release notes
This releases fixes a few Drupal 9 compatibility problems and bugs:

#3031671: PanelizerWizardContextForm calls parent constructor without enough arguments under CTools 3.1
#3131404: Ensure tests pass on Drupal 9
# panelizer 8.x-4.3
## Release notes
This is a bug and deprecation release of panelizer. It officially supports Drupal 9.

This version requires Drupal 8.8. If you need to use 8.7 or lower, use Panelizer 4.2

Most of the changes were done in the 5.x branch and ported to 4.x, see below:

Issue #3124333 by japerry: Require Drupal 8.8, some new methods don't work in 8.7.
Issue #3042712 by japerry: Update QuickEdit Test.
Issue #3042712 by japerry: Follow fix tests for 4.x branch.
Issue #3124333 by japerry: Update PanelizerQuickEditTest to D9.
Issue #3114915 by phenaproxima: Fix tests on Drupal 9
Issue #3113675 by thalles: Fix subclassing and stop overriding constructors in panelizer\Form\PanelizerWizardContextConfigure
Issue #3108062 by phenaproxima: Remove deprecated code usage
Issue #3042712 by pranit84, sandboxpl, Sergiu Stici, DrupalZone, amitgoyal, joshi.rohit100: Drupal 9 Deprecated Code Report
Issue #3124333 by japerry: Drupal 9 Support, Require D8.6+

# panelizer 8.x-4.2
## Release notes
This release fixes incompatibilities with current versions of Panels and CTools. Therefore, it also requires at least CTools 3.1 and Panels 4.4.

Issues fixed:

#3104251: Fix test failures and bump required versions of CTools and Panels