### PR TITLE
[GOVCMSD8-501] update panels 8.x-4.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "drupal/module_filter": "3.1",
         "drupal/page_manager": "4.0-beta4",
         "drupal/panelizer": "4.1",
-        "drupal/panels": "4.4.0",
+        "drupal/panels": "4.6.0",
         "drupal/paragraphs": "1.12",
         "drupal/password_policy": "3.0-beta1",
         "drupal/pathauto": "1.8.0",


### PR DESCRIPTION
# panels 8.x-4.6
## Release notes
This is the first officially supported Drupal 9 version of Panels.

Note, this requires Drupal 8.8 and above. No other changes were made between 4.6 and 4.5 except removing deprecations.
# panels 8.x-4.5
## Release notes
This is an incremental update to Panels, which includes various bug releases.

This is the last version of Panels to support Drupal 8.5, 8.6, and 8.7

Changes since 8.x-4.4:

Issue #3030976 by phenaproxima, bendeguz.csirmaz, colincalnan: Panels should check if there is an icon map before setting the no preview icon
Issue #3114373 by phenaproxima: Require jQuery UI shim modules
Issue #3109899 follow-up by phenaproxima, tim.plunkett: Declare compatibility with Drupal 9
Issue #3109899 by phenaproxima, tim.plunkett: Declare compatibility with Drupal 9
Issue #3070866 by Mohammad Fayoumi, joseph.olstad: Drupal 9 replace deprecated function drupal_set_message()
Issue #3107784 by phenaproxima: Convert tests to PHPUnit
Issue #3107809 by phenaproxima, tim.plunkett: Make tests run on Drupal core 8.8 and later
Issue #2769801 by lamp5, DamienMcKenna, tobiberlin, joelpittet, benjy, sylus, Sinan Erdem, millionleaves, manuel.adan: Enable token browser for the page variant title field
Issue #3045578 by tengoku: Bug Report: ( ! ) Warning: array_unique() expects parameter 1 to be array, string in Attributes.php on line 66
#