### PR TITLE
[GOVCMSD8-505] permissions_by_term 3.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "drupal/paragraphs": "1.12",
         "drupal/password_policy": "3.0-beta1",
         "drupal/pathauto": "1.8.0",
-        "drupal/permissions_by_term": "2.12",
+        "drupal/permissions_by_term": "3.1.1",
         "drupal/real_aes": "2.3",
         "drupal/recaptcha": "2.4",
         "drupal/redirect": "1.3",


### PR DESCRIPTION
# permissions_by_term 3.1.1
## Release notes
Drupal 9 only compatibility by updating the "core_version_requirement" in the pbt_entity_test module.
# permissions_by_term 3.1.0
## Release notes
New feature
#3137145 - Assign terms to users via user edit form: You are now able to limit permissions management and search by selected taxonomy vocabularies from the Permissions by Term configuration form. Also you can select the permitted taxonomy terms by the user edit admin form. This makes permissions management with a lot of taxonomy terms and users easier. Big thanks to Dropsolid and nginex, PieterDC for contribution!
# permissions_by_term 3.0.1
## Release notes
The 3.0.x version requires Drupal 9, because it does not contain any Symfony deprecations. As a result Drupal 8.x is not supported in the 3.0.x branch. If you need to use Drupal 8.x, then use the 8.x-2.x branch.
# permissions_by_term 3.0.0
## Release notes
Solved compatibility with Drupal 9.

See the following issues:

#3136115 - Drupal 9 Readiness
#3148414 - Automated Drupal 9 compatibility fixes