### PR TITLE
[GOVCMSD8-509] update scheduled_transitions 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "drupal/redirect": "1.3",
         "drupal/restui": "1.16.0",
         "drupal/robotstxt": "1.4",
-        "drupal/scheduled_transitions": "1.0.0-rc1",
+        "drupal/scheduled_transitions": "2.0",
         "drupal/search_api": "1.16",
         "drupal/search_api_solr": "3.9",
         "drupal/search_api_attachments": "1.0-beta16",


### PR DESCRIPTION
# scheduled_transitions 2.0.0
## Release notes
Drupal 8 + 9 compatible version

Contributors (1)
dpi

Changelog
Issues: 3 issues resolved.

Changes since 8.x-1.1-beta3:

Feature
#3132310 by dpi: Fixed D9 deprecations
Task
#3165181 by dpi: Improve DX of field values for Scheduled Transitions entities
#3132303: Upgrade D8.9 / D9 constraints