### PR TITLE
[GOVCMSD8-519] update video_embed_field 8.x-2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,7 @@
         "drupal/token": "1.7",
         "drupal/update_notifications_disable": "1.0",
         "drupal/username_enumeration_prevention": "1.0-beta2",
-        "drupal/video_embed_field": "2.0",
+        "drupal/video_embed_field": "2.4",
         "drupal/webform": "5.13",
         "oomphinc/composer-installers-extender": "^1.1",
         "swiftmailer/swiftmailer": "5.4.12",


### PR DESCRIPTION
# video_embed_field 8.x-2.4
## Release notes
A D9 ready release, with all tests passing thanks to the efforts of @phenaproxima and @katherined.

Contributors (3)
katherined, phenaproxima, dpi

Changelog
Issues: 4 issues resolved.

Changes since 8.x-2.3:

Feature
#3122182 by dpi: Make VEF to core Drush migration commands consistent between Drush 8/9+
Task
#3128050 by katherined, phenaproxima: Pass tests with Drupal 9
#3128373 by katherined: Remove test dependency on Media Entity
#3122349 by katherined: Remove core key from test module info file