### PR TITLE
[GOVCMSD8-491] update linked_field 1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "drupal/honeypot": "1.29",
         "drupal/inline_entity_form": "1.0-rc1",
         "drupal/key": "1.14",
-        "drupal/linked_field": "1.1.0",
+        "drupal/linked_field": "1.3.0",
         "drupal/linkit": "5.0-beta9",
         "drupal/login_security": "1.5",
         "drupal/media_entity_file_replace": "1.0-beta2",


### PR DESCRIPTION
# linked_field 1.3
## Release notes
#3112209: Site unavailable after update of LinkedField module
# linked_field 8.x-1.2
## Release notes
The new version of Linked Field includes lots of changes:

#3095818: Webprofiler trying to wrap things causes error due to class instead of interface passed into plugin
#3000461: Coding standard
#3091449: Make module ready for Drupal 9
#2970970: Dependency Injection issues
#2992108: Error when updating field settings in manage display
#3000461: Coding standard
#3042830: Drupal 9 Deprecated Code Report
#3060776: ResponseText: Error: Cannot use object of type
#3049135: Undefined index: linked when adding fields through Layout Builder
#3049007: Layout Builder undefined #bundle
#2987464: Linked field are not compatible with layout builder
#2952482: Undefined index: #type when using Token module (optional dependency)