### PR TITLE
[GOVCMSD8-508] update restui 8.x-1.18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "drupal/real_aes": "2.3",
         "drupal/recaptcha": "2.4",
         "drupal/redirect": "1.3",
-        "drupal/restui": "1.16.0",
+        "drupal/restui": "1.18.0",
         "drupal/robotstxt": "1.4",
         "drupal/scheduled_transitions": "1.0.0-rc1",
         "drupal/search_api": "1.16",


### PR DESCRIPTION
# restui 8.x-1.18
## Release notes
Make compatibility with Drupal 9 and bug fixes.

git log ...8.x-1.17

- Issue #3108710: t() calls should be avoided in classes, use \Drupal\Core\StringTranslation\StringTranslationTrait and $this->t() instead by rksyrav
- Issue #3124927: Test failed on missing theme setting by clemens.tolboom
- Issue #3097932: Drupal 9: update project page to indicate this project is already done + update *.info.yml by Wim Leers, rksyravi, Chris Matthews
- Issue #3064392: Coding standard fixes by oknate, clemens.tolboom
- Issue #3059446: Change Namespace for RestUITest.php tests by Krzysztof Domański, clemens.tolboom, Wim Leers
- Issue #3059446: Change Namespace for RestUITest.php tests by Krzysztof Domański

# restui 8.x-1.17
## Release notes
Breaks D8.5.x and lower.
This release is only usable for supported Drupal 8 versions. That is this version is not for D8.5.x which is unsupported as D8.7.x is released since May 1, 2019

Fixed
Prepare for D9 by removing deprecated code

- #3008193: Removing deprecated JavascriptTestBase Class

Typo

- #3045383: Module Description: add dot to the end of the sentence