### PR TITLE
[GOVCMSD8-488] update graphql 8.x-4.0-beta2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "drupal/govcms_dlm": "1.3",
         "drupal/govcms8_ui": "1.0.0-alpha1",
         "drupal/govcms8_uikit_starter": "1.0-alpha2",
-        "drupal/graphql": "3.0.0-rc2",
+        "drupal/graphql": "4.0-beta2",
         "drupal/honeypot": "1.29",
         "drupal/inline_entity_form": "1.0-rc1",
         "drupal/key": "1.14",


### PR DESCRIPTION
# graphql 8.x-4.0-beta2
## Release notes
This is the second beta release of the graphql module for Drupal, code name "Persistent Stan Fan"!

This release adds support for Persisted Queries and we did a lot Coding Standards cleanups.

Full list of changes since 4.0-beta2: https://github.com/drupal-graphql/graphql/compare/8.x-4.0-beta1...8.x-4....

We are planing a stable release of graphql module in https://github.com/drupal-graphql/graphql/issues/936

Big thanks to Vasi Chindris, rthideaway, Dylan203, joaogarin and all other contributors who helped make this module better.

Warning: the 4.x branch is under development and not fully stable. We try to avoid API breaks in future beta releases, but they can happen. Please do extensive testing when upgrading this module.

The documentation on how to use and implement graphql 4.x for your project is work in progress and can be found here: https://github.com/drupal-graphql/graphql/blob/8.x-4.x/doc/SUMMARY.md