### PR TITLE
Add `chosen` dependency to allow builds to succeed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "drupal/adminimal_theme": "1.4",
         "drupal/bigmenu": "2.0.0-rc1",
         "drupal/chosen": "2.9.0",
+        "drupal/chosen_lib": "2.9.0",
         "drupal/components": "1.0.0",
         "drupal/config_filter": "1.5",
         "drupal/config_ignore": "2.1",


### PR DESCRIPTION
Currently GovCMS8Lagoon builds are failing due to a dependency solution. I'll test this one independently, however if this is not included, I will not be able to produce release artifacts in the next release cycle.

```
  Problem 1
    - govcms/govcms dev-release/8.x-1.10 requires drupal/chosen 2.9.0 -> satisfiable by drupal/chosen[2.9.0].
    - govcms/govcms dev-release/8.x-1.10 requires drupal/chosen 2.9.0 -> satisfiable by drupal/chosen[2.9.0].
    - Can only install one of: drupal/chosen[2.9.0, 2.6.0].
    - drupal/chosen_lib 2.6.0 requires drupal/chosen 2.6.0 -> satisfiable by drupal/chosen[2.6.0].
    - Installation request for drupal/chosen_lib 2.6.0 -> satisfiable by drupal/chosen_lib[2.6.0].
    - Installation request for govcms/govcms dev-release/8.x-1.10 -> satisfiable by govcms/govcms[dev-release/8.x-1.10].
```