### PR TITLE
[GOVCMSD8-734] Add missing chosen_lib dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "drupal/adminimal_theme": "1.4",
         "drupal/bigmenu": "2.0.0-rc1",
         "drupal/chosen": "2.9.0",
+        "drupal/chosen_lib": "2.9.0",
         "drupal/components": "1.0.0",
         "drupal/config_filter": "1.5",
         "drupal/config_ignore": "2.1",
@@ -141,7 +142,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/admin_toolbar": {
-                "Vertical tab display bug after page reload - https://www.drupal.org/project/admin_toolbar/issues/3154104": "https://www.drupal.org/files/issues/2020-06-23/admin_toolbar-vertical-display-fix-3154104-2-D8.patch" 
+                "Vertical tab display bug after page reload - https://www.drupal.org/project/admin_toolbar/issues/3154104": "https://www.drupal.org/files/issues/2020-06-23/admin_toolbar-vertical-display-fix-3154104-2-D8.patch"
             },
             "drupal/config_ignore": {
                 "Offset error within IgnoreFilter::activeReadMultiple() - https://www.drupal.org/project/config_ignore/issues/2972302": "https://www.drupal.org/files/issues/2018-07-31/offset-error-within-2972302-13.patch"


### PR DESCRIPTION
The `drupal/chosen` module requires `drupal/chosen_lib` to operate correctly.

Currently this is (incorrectly) being injected in `scaffold-tooling`, but should be removed for this release (https://github.com/govCMS/scaffold-tooling/pull/72/files) as this is a distribution dependency, not tooling.