### PR TITLE
Update Drupal core to v8.9.7

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.9.6",
+        "drupal/core-recommended": "8.9.7",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "drupal/consumers": "1.9",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta2",
-        "drupal/core-recommended": "8.9.6",
+        "drupal/core-recommended": "8.9.7",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.2.0",
         "drupal/diff": "1.0",


### PR DESCRIPTION
[Source](https://www.drupal.org/project/drupal/releases/9.0.7)

## Release notes

This is a patch (bugfix) release of Drupal 9 and is ready for use on production sites. Learn more about Drupal 9.

Drupal 9.0.x will receive security coverage until June 2, 2021 when Drupal 9.2.0 is released.

If you are upgrading from Drupal 8, read upgrading a Drupal 8 site to Drupal 9 and the 9.0.0 release notes before upgrading to this release.

If your site is on 8.8.x or earlier, you may wish to upgrade to Drupal 8.9.3 instead, and upgrade to Drupal 9 at a later date after preparing your site.

## Important update information

This release has been tagged with Composer 2.0.0-RC1. Please report any issues in the Drupal core issue queue.
Known issues

Search the issue queue for known issues.

## All changes since Drupal 9.0.6
````
Issue #3168301 by chr.fritsch, phenaproxima: oEmbed validator should use the urlResolver to get the resource URL
Issue #3174569 by paulocs: Fix English mistake in Connection.php
Issue #3110064 by idebr, chandrashekhar_srijan, Vidushi Mehta, ckng, benjifisher, mikelutz: Migrate empty, and link field
Issue #3173873 by shetpooja04: Unused variable $pos in SearchQuery.php, search module
Issue #3156949 by ytsurk, Berdir: Filename is not shown in the maximum allowed file size error message (w/o using the file_validate_size upload validator)
Issue #2904546 by mrweiner, vsujeetkumar, quietone, dev.patrick, MaskOta, msuthars, sarvjeetsingh, abhisekmazumdar, vacho, heddn, alexpott: admin/reports/upgrade redirect doesn't handle view arguments when enabled
Issue #3173976 by shetpooja04: Remove unused variable $file_path in ConfigTest.php, system module
Issue #3170020 by gabesullice, e0ipso, Wim Leers: The sunset of the API-first initiative
Issue #3173437 by anmolgoyal74: Repeative 'or' word in FieldOptionTranslation.php
Issue #3173435 by anmolgoyal74: Repeated 'not' word in PharExtensionInterceptor.php
Issue #3119254 by quietone, shaktik, douggreen, larowlan: [backport] Add taxonomy_term_reference_plain and taxonomy_term_reference_rss_category to TaxonomyTermReference
Issue #2586013 by g-brodiei, pameeela, ayushmishra206, Vidushi Mehta, willzyx, LoMo, larowlan, longwave, Lendude, catch: [backport] node_views_analyze() is never executed because it is in the wrong inc file
Issue #2949400 by ayushmishra206, chandrashekhar_srijan, bandanasharma, marvil07, AkashkumarOSL, quietone, mikelutz: MigrateProcessInterface documents ProcessPluginBase behaviour
Issue #3158262 by S_Bhandari: Remove Unused variable from Path Alias module
Issue #3098282 by quietone, raman.b, Vidushi Mehta, mikelutz, ankithashetty, alexpott, gapple, larowlan, xjm: SQL error if migration has too many ID fields
Issue #3152320 by bircher, nedjo, tstoeckler: ExtensionInstallStorage::createCollection() produces error
Issue #3143721 by quietone, raman.b, mikelutz: Create a separate SourceProviderTest
Issue #3171510 by quietone: Add documentation for default_bundle to destination\Entity
Issue #3173037 by bnjmnm: Prettier not run on Ckeditors imagecaption's plugin.es6.js
Issue #3172425 by mikelutz, catch: "Symfony\Component\Lock\Factory" is deprecated since Symfony 4.4 and will be removed in 5.0 use "Symfony\Component\Lock\LockFactory" instead
Issue #3156878 by alexpott, andypost: \Drupal\Component\Datetime\DateTimePlus should pass correct parameter types to checkdate()
Issue #3171743 by chr.fritsch, paulocs, Berdir, phenaproxima: Not possible to overwrite the upload forms for media library
Issue #2132773 by g-brodiei, killes@www.drop.org, DevJoJodae, jonathanshaw, dawehner: Don't add term_access tag if SQL rewriting off
Issue #3171366 by bnjmnm: Comments from variables.pcss.css create nonuseful noise in compiled css
Issue #3165763 by quietone, mikelutz: Combine two tests to one in d7 MigrateFieldTest and MigrateFieldInstance
Issue #2678510 by larowlan, quietone, ankithashetty, samiullah, alexpott: Remove @todos from migrate credentials form
Issue #3166360 by lauriii: Disable csslint testing in core
Issue #2821352 by chr.fritsch, jian he, Pancho, RaphaelBriskie, jonathanshaw, alexpott, amateescu, larowlan: EntityReferenceAutocompleteWidget::getAutocreateBundle() unnecessarily requires the 'target_bundles' setting
Issue #3170246 by paulocs, longwave: NodeLoadMultipleTest.php should be a kernel test
    by xjm: More coding standards fixes.
    SA-CORE-2020-011 followup by xjm: Clean up coding standards in test.
    Back to dev.
    Merged 9.0.6.
Issue #3170648 by hussainweb: CKEditorPluginManager::getEnabledButtons throws warnings on PHP 8.0.0 beta3
Issue #2969551 by quietone, mikelutz, joachim, benjifisher, catch: Migrate messages from caught exceptions need file and line details
Issue #315176 by Dave Reid, andypost, franz, sun, Alan D.: Clean-up remains of $form['array_filter'] hack with array_filter in book module
Issue #3110839 by quietone, jungle: Use of \Drupal\Core\Database\Install\Tasks::getFormOptions() in \Drupal\migrate_drupal_ui\Form\CredentialForm::buildForm() results in confusing description for prefix form element
Issue #2822334 by jungle, mbovan, longwave, Kristen Pol, quietone: Unicode::mimeHeaderDecode() doesn't support lowercased encoding
Issue #3101045 by quietone, mikelutz, Stefan Kangas, NiklasBr: LanguageContentSettingsTaxonomyVocabulary source plugin should only add language column if it exists
Issue #3159101 by Wim Leers: SQLBase::mapjoinable still does not support SQLite
Issue #3156885 by andypost, Gábor Hojtsy: Change \Drupal\error_test\Controller\ErrorTestController::generateWarnings() to throw E_NOTICE error compatible with PHP 8
Issue #3122002 by clayfreeman, lauriii, alexpott: Remove dependency to localize.drupal.org on Nightwatch tests
Issue #3159849 by quietone, mikelutz: Add missing tests of filepath to FileTest
````