### PR TITLE
[GOVCMSD8-670] Update drupal/components to 2.0-beta3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "drupal/adminimal_theme": "1.4",
         "drupal/bigmenu": "2.0.0-rc1",
         "drupal/chosen": "2.9.0",
-        "drupal/components": "1.0.0",
+        "drupal/components": "2.0-beta3",
         "drupal/config_filter": "1.5",
         "drupal/config_ignore": "2.1",
         "drupal/config_perms": "1.2.0",


### PR DESCRIPTION
# components 8.x-2.0-beta1
## Release notes
#3081314: Add Twig filters to set deeply nested properties
#3092925: Add composer.json
#3091762: Rename "component-libraries" key in info.yml file
#3027672: Any other theme can override the active theme's component-libraries
#3091827: Use variadic arguments for template function
#3091775: Rename theme Twig function to be called 'template()'
#3090458: Remove theme tag
#3082149: Remove namespace_prefix setting
# components 8.x-2.0-beta2
## Release notes
#3100006: [error] on install (the 'core' key in *.info should not be set after Drupal core ^8.7.7)
# components 8.x-2.0-beta3
## Release notes
The Components module should now be 100% Drupal 9 compatible. #3112929: Drupal 9 Deprecated Code Report for Components module