### PR TITLE
[GOVCMSD8-778] Patch for Context module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,7 +151,7 @@
               "Replace deprecated AllowedTagsXssTrait": "https://www.drupal.org/files/issues/2020-04-17/3128413-10.patch"
             },
              "drupal/context": {
-                 "Error: Call to a member function getCacheTags - https://www.drupal.org/project/context/issues/3173470" : "https://www.drupal.org/files/issues/2020-11-05/context-3173470-13.patch"
+                 "Error: Call to a member function getCacheTags - https://www.drupal.org/project/context/issues/3173470" : "https://www.drupal.org/files/issues/2020-11-10/context-3173470-16.patch"
              },
             "drupal/core": {
                 "Private file download returns access denied, when file attached to revision other than current - https://www.drupal.org/project/drupal/issues/1452100#comment-13653216": "https://www.drupal.org/files/issues/2020-05-29/1452100-file-access-97.patch"


### PR DESCRIPTION
### Background
A fatal error related to Context module brings a white screen with the error "The website encountered an unexpected error. Please try again later."

The error message in PHP logs is "Error: Call to a member function getCacheTags() on null in Drupal\context\Plugin\ContextReaction\Blocks->execute() (line 252 of modules/~context/context/src/Plugin/ContextReaction/Blocks.php)"

This issue has been reported to Drupal.org.
https://www.drupal.org/project/context/issues/3173470

### Proposed Solution:
A patch for Context module to avoid the fatal error. So that the web page still can be rendered without any error.

### Remained task
Fix the data integrity issue with Context configurations.

