### PR TITLE
Patch to stop PHP notices in the token module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/admin_toolbar": {
-                "Vertical tab display bug after page reload - https://www.drupal.org/project/admin_toolbar/issues/3154104": "https://www.drupal.org/files/issues/2020-06-23/admin_toolbar-vertical-display-fix-3154104-2-D8.patch" 
+                "Vertical tab display bug after page reload - https://www.drupal.org/project/admin_toolbar/issues/3154104": "https://www.drupal.org/files/issues/2020-06-23/admin_toolbar-vertical-display-fix-3154104-2-D8.patch"
             },
             "drupal/config_ignore": {
                 "Offset error within IgnoreFilter::activeReadMultiple() - https://www.drupal.org/project/config_ignore/issues/2972302": "https://www.drupal.org/files/issues/2018-07-31/offset-error-within-2972302-13.patch"
@@ -197,9 +197,12 @@
                 "Create Email one-time-code Validation Plugin & related Setup Plugin - https://www.drupal.org/project/tfa/issues/2930541": "https://www.drupal.org/files/issues/2020-08-12/tfa-2930541-16.patch"
             },
             "drupal/webform": {
-                "Undefined index: messages - https://www.drupal.org/project/webform/issues/3137625" :"https://www.drupal.org/files/issues/2020-05-18/3137625-3.patch",
+                "Undefined index: messages - https://www.drupal.org/project/webform/issues/3137625": "https://www.drupal.org/files/issues/2020-05-18/3137625-3.patch",
                 "Email from name cannot be longer than 128 characters - https://www.drupal.org/project/webform/issues/3142807": "https://www.drupal.org/files/issues/2020-05-26/3142807-9.patch",
                 "Email confirmation clientside validation not working - https://www.drupal.org/project/webform/issues/3138266": "https://www.drupal.org/files/issues/2020-05-20/3138266-5.patch"
+            },
+            "drupal/token": {
+                "token_element_children produce notice on integer keys - https://www.drupal.org/project/token/issues/3154183": "https://www.drupal.org/files/issues/2020-06-23/3154183-2.patch"
             }
         }
     },


### PR DESCRIPTION
### This patch needs testing

In the token module, when using token [node:book:parents:join-path] to create content that is assigned to a parnet book, PHP notice is getting triggered:
`Notice: Trying to access array offset on value of type int in token_element_children() (line 608 of modules/contrib/token/token.module).token_element_children(Array, 1) (Line: 945)
token_tokens('array', Array, Array, Array, Object)
call_user_func_array('token_tokens', Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler->invokeAll('tokens', Array) (Line: 304)
Drupal\Core\Utility\Token->generate('array', Array, Array, Array, Object) (Line: 1155)
book_tokens('book', Array, Array, Array, Object)
call_user_func_array('book_tokens', Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler->invokeAll('tokens', Array) (Line: 304)
Drupal\Core\Utility\Token->generate('book', Array, Array, Array, Object) (Line: 1110)
book_tokens('node', Array, Array, Array, Object)
call_user_func_array('book_tokens', Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler->invokeAll('tokens', Array) (Line: 304)
Drupal\Core\Utility\Token->generate('node', Array, Array, Array, Object) (Line: 196)
Drupal\Core\Utility\Token->replace('resources/[node:book:parents:join-path]/[node:title]', Array, Array, Object) (Line: 228)
Drupal\pathauto\PathautoGenerator->createEntityAlias(Object, 'update') (Line: 380)
Drupal\pathauto\PathautoGenerator->updateEntityAlias(Object, 'update') (Line: 93)
pathauto_entity_update(Object)
call_user_func_array('pathauto_entity_update', Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler->invokeAll('entity_update', Array) (Line: 206)
Drupal\Core\Entity\EntityStorageBase->invokeHook('update', Object) (Line: 843)
Drupal\Core\Entity\ContentEntityStorageBase->invokeHook('update', Object) (Line: 535)
Drupal\Core\Entity\EntityStorageBase->doPostSave(Object, 1) (Line: 728)
Drupal\Core\Entity\ContentEntityStorageBase->doPostSave(Object, 1) (Line: 460)
Drupal\Core\Entity\EntityStorageBase->save(Object) (Line: 837)
Drupal\Core\Entity\Sql\SqlContentEntityStorage->save(Object) (Line: 395)
Drupal\Core\Entity\EntityBase->save() (Line: 294)
Drupal\node\NodeForm->save(Array, Object)
call_user_func_array(Array, Array) (Line: 114)
Drupal\Core\Form\FormSubmitter->executeSubmitHandlers(Array, Object) (Line: 52)
Drupal\Core\Form\FormSubmitter->doSubmitForm(Array, Object) (Line: 593)
Drupal\Core\Form\FormBuilder->processForm('node_report_content_edit_form', Array, Object) (Line: 321)
Drupal\Core\Form\FormBuilder->buildForm(Object, Object) (Line: 91)
Drupal\Core\Controller\FormController->getContentResult(Object, Object)
call_user_func_array(Array, Array) (Line: 123)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 573)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 124)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array) (Line: 97)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 151)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 68)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 50)
Drupal\ban\BanMiddleware->handle(Object, 1, 1) (Line: 115)
Drupal\shield\ShieldMiddleware->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 708)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)`

This PR applies the patch #2 from https://www.drupal.org/project/token/issues/3154183