### PR TITLE
Release/8.x 1.12

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.9.7",
+        "drupal/core-recommended": "8.9.9",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",

--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,9 @@
               "Update code deprecated in 8.8": "https://www.drupal.org/files/issues/2020-04-10/3081195-21-PASS.patch",
               "Replace deprecated AllowedTagsXssTrait": "https://www.drupal.org/files/issues/2020-04-17/3128413-10.patch"
             },
+             "drupal/context": {
+                 "Error: Call to a member function getCacheTags - https://www.drupal.org/project/context/issues/3173470" : "https://www.drupal.org/files/issues/2020-11-05/context-3173470-13.patch"
+             },
             "drupal/core": {
                 "Private file download returns access denied, when file attached to revision other than current - https://www.drupal.org/project/drupal/issues/1452100#comment-13653216": "https://www.drupal.org/files/issues/2020-05-29/1452100-file-access-97.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "drupal/consumers": "1.11",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta5",
-        "drupal/core-recommended": "8.9.7",
+        "drupal/core-recommended": "8.9.9",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.4.0",
         "drupal/diff": "1.0",


### PR DESCRIPTION
### Drupal core update:
From 8.9.7 to 8.9.9

### Bug fixed (1):
- Context module ([Error: Call to a member function getCacheTags](https://www.drupal.org/project/context/issues/3173470))