### PR TITLE
[GOVCMSD8-792] Update Core to 8.9.11 from 8.9.9

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.9.9",
+        "drupal/core-recommended": "8.9.11",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "drupal/consumers": "1.11",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta5",
-        "drupal/core-recommended": "8.9.9",
+        "drupal/core-recommended": "8.9.11",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.4.0",
         "drupal/diff": "1.0",


### PR DESCRIPTION
Drupal 8.9.11 is a patch (bugfix) release of Drupal 8 and is ready for use on production sites.

Known issues
Search the issue queue for known issues.

 

Release note:

https://www.drupal.org/project/drupal/releases/8.9.11