### PR TITLE
[GOVCMSD9-55] Deprecate custom module: govcms_search

### DIFF
--- a/govcms.info.yml
+++ b/govcms.info.yml
@@ -82,7 +82,6 @@ dependencies:
   - username_enumeration_prevention
 
   # govCMS core modules
-  - govcms_search
   - govcms_media
   - govcms8_foundations
   - govcms_blog_article

--- a/modules/deprecated/govcms_search.info.yml
+++ b/modules/deprecated/govcms_search.info.yml
@@ -1,0 +1,6 @@
+name: GovCMS Search
+type: module
+description: Provide default search functions.
+package: GovCMS8 [deprecated]
+core: 8.x
+core_version_requirement: ^8 || ^9


### PR DESCRIPTION
## Problem/Motivation
This is an out of date module in GovCMS8 for providing the default database search configurations.

https://github.com/govCMS/GovCMS8/tree/1.x/modules/custom/core/govcms_search

## Proposed resolution
govcms_search shall be deprecated from the GovCMS9 distribution

Create a stub module in https://github.com/govCMS/GovCMS/tree/2.x/modules/deprecated
Clean up the code base after the site migration
A set of optional Drupal configs can be provided for testing purposes - Copy https://github.com/govCMS/GovCMS8/tree/1.x/modules/custom/core/govcms_search/config/install to https://github.com/govCMS/GovCMS8/tree/1.x/config/optional