### PR TITLE
[GOVCMSD8-507] Update redirect to 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "drupal/permissions_by_term": "2.12",
         "drupal/real_aes": "2.3",
         "drupal/recaptcha": "2.4",
-        "drupal/redirect": "1.3",
+        "drupal/redirect": "1.6",
         "drupal/restui": "1.16.0",
         "drupal/robotstxt": "1.4",
         "drupal/scheduled_transitions": "2.0",


### PR DESCRIPTION
## redirect 8.x-1.6
### Release notes
Drupal 9 compatibility. Requires Drupal 8.8.

Contributors (9)
Berdir, DamienMcKenna, lolandese, phenaproxima, WidgetsBurritos, chr.fritsch, daniel.bosen, Morbus Iff, andralex

Changelog
Issues: 9 issues resolved.

Changes since 8.x-1.5:

Task
#3135968 by Berdir: Fixing new/remaining Drupal 9 test fails
#3127562 by DamienMcKenna: Document why the domain redirect "host" value is converted
#3131070 by lolandese: License "GPL-2.0+" is a deprecated SPDX license identifier
#3132121 by phenaproxima: Make core_version_requirement consistent in all info files
#3065229 by WidgetsBurritos: Clarify redirect_domain precedence
#3089389 by chr.fritsch, daniel.bosen: Update view to met the Drupal 8.8 views schema
#3102143 by Berdir, phenaproxima, andralex: Remove Drupal 8.8 deprecations, compatibility with Drupal 9