### PR TITLE
[GOVCMSD8-807] Update components to 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "drupal/adminimal_theme": "1.4",
         "drupal/bigmenu": "2.0.0-rc1",
         "drupal/chosen": "2.9.0",
-        "drupal/components": "2.0-beta3",
+        "drupal/components": "2.2",
         "drupal/config_filter": "1.5",
         "drupal/config_ignore": "2.1",
         "drupal/config_perms": "1.2.0",


### PR DESCRIPTION
## components 8.x-2.2
### Release notes
Bug fixes since 8.x-2.1:

#3165589: Incorrect theme loaded when critical_css module is installed
## components 8.x-2.1
### Release notes
New features and bug fixes since 8.x-2.0:

#3191968: Add alter hook for protected Twig namespaces
#3191956: Warn when trying to use protected namespace
#3192012: Warn about using deprecated API
#3192697: Prevent dblog warnings with every page load or drush command
Prevent invalid components data from throwing PHP error
## components 8.x-2.0
### Release notes
New features since 8.x-2.0-beta3:

#3151880: Allow paths relative to Drupal root
Changes since 8.x-1.1:

#3082149: Remove namespace_prefix setting
#3042625: Drupal 9 Deprecated Code Report
#3090458: Remove theme tag
#3091775: Rename theme Twig function to be called 'template()'
#3091827: Use variadic arguments for template function
#3027672: Any other theme can override the active theme's component-libraries
#3091762: Rename "component-libraries" key in info.yml file
#3081314: Add Twig filters to set deeply nested properties
Drupal 9 support
Full test coverage