### PR TITLE
[GOVCMSD8-746] update media_entity_file_replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "drupal/linked_field": "1.3.0",
         "drupal/linkit": "5.0-beta9",
         "drupal/login_security": "2.0",
-        "drupal/media_entity_file_replace": "1.0-beta2",
+        "drupal/media_entity_file_replace": "1.0-beta3",
         "drupal/memcache": "2.0",
         "drupal/menu_block": "1.6",
         "drupal/menu_trail_by_path": "1.1",


### PR DESCRIPTION
## media_entity_file_replace 8.x-1.0-beta3 
### Release notes
Lots of bug fixes and D9 compatibility:

#3114642: Missing @group annotation in Drupal\Tests\media_entity_file_replace\Functional\MediaEntityFileReplaceTest
#3106363: Clear image cache after updating media image
#3109689: Force replacement files to have the same extension
#3105867: README.txt is not fully descriptive
#3128347: Error: Call to a member function getUploadValidators() on null
#3148047: Automated Drupal 9 compatibility fixes
#3131560: Perform replacement at an earlier stage to improve DX
#3130452: Prepare destination directory before saving replacement file
#3154276: Media form save validation error using Media Entity File Replace if file was separately deleted
Dropped support for Drupal versions older than 8.7.7.