### PR TITLE
[GOVCMSD8-735] Update encrypt to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "drupal/devel": "4.0.1",
         "drupal/dropzonejs": "2.1",
         "drupal/ds": "3.9",
-        "drupal/encrypt": "3.0-rc2",
+        "drupal/encrypt": "3.0",
         "drupal/dynamic_entity_reference": "1.10.0",
         "drupal/entity_browser": "2.5",
         "drupal/entity_class_formatter": "1.3",


### PR DESCRIPTION
## encrypt 8.x-3.0
### Release notes
This is the first full release of Encrypt 3.x.

Contributors (4)
jcnventura, rlhawk, gena.io, Arkener

Changelog
Issues: 7 issues resolved.

Changes since 8.x-3.0-rc3:

Bug
#3163950 by jcnventura: t() calls should be avoided in classes
#3147117 by jcnventura: Update readme.md for D9
Feature
#3162975 by jcnventura: Add annotation to mark encryption plugins as deprecated
#3163869 by jcnventura: Fix 16 coding standards messages
#3157463 by Arkener: Throw tag on EncryptionMethodInterface
Task
#3162867 by rlhawk: Add security warning to permission
#3155530 by gena.io: Replace assert* involving an instanceof operator with assertInstanceOf()/assertNotInstanceOf()