### PR TITLE
[GOVCMSD8-736] update ga_login from 1.0-alpha4 to 1.0-alpha6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -164,9 +164,6 @@
                 "Skip password logging during failed authentication attempt - https://www.drupal.org/project/events_log_track/issues/3027463": "https://www.drupal.org/files/issues/2019-01-22/event-log-track-auth-3027463-2.patch",
                 "Fix fatal error when we request password with non-existing users/emails on the Events Log Track User Authentication - https://www.drupal.org/project/events_log_track/issues/3060838#comment-13141212": "https://www.drupal.org/files/issues/2019-06-11/3060838-4.patch"
             },
-            "drupal/ga_login": {
-                "TOTP taking very-old verification codes - https://www.drupal.org/project/ga_login/issues/3022921": "https://www.drupal.org/files/issues/2018-12-28/3022921-2-time-skew-confusing.patch"
-            },
             "drupal/google_analytics": {
                "Fatal error when there is a view with the path search/node":  "https://www.drupal.org/files/issues/2018-06-18/patch_google_analytics.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "drupal/features": "3.8",
         "drupal/field_group": "3.1",
         "drupal/focal_point": "1.4",
-        "drupal/ga_login": "1.0-alpha4",
+        "drupal/ga_login": "1.0-alpha6",
         "drupal/google_analytics": "3.0",
         "drupal/govcms_dlm": "1.4",
         "drupal/govcms8_ui": "1.0.0-alpha1",


### PR DESCRIPTION
## ga_login 8.x-1.0-alpha6
### Release notes
Changes since 8.x-1.0-alpha5:

#2938085 by screon, jcnventura: Define setup plugin id annotation as the TFA module api changes
#3184520 by jcnventura: Move to the Security module group
#2932976 by jcnventura: Rename plugin IDs in users_data.
## ga_login 8.x-1.0-alpha5
### Release notes
Changes since 8.x-1.0-alpha4:

Depends on tfa 8.x-1.0-alpha5 or later
#3166749 by jcnventura: "Use site name as OTP QR code name prefix." config not saving correctly
#3166748 by jcnventura: Delete obsolete GALoginRecoveryCodeSetup plugin
#3090072 by idebr, jcnventura: Use form action wrapper with a primary button for a consistent user interface experience
#3166746 by jcnventura: Declare parameter of getOverview() as array
#2932976 by JeroenT, jcnventura: Do not use tfa prefix for plugins in the ga_login module
#3159392 by jcnventura: Fix coding standards
#3120760 by jcnventura, acbramley, Suresh Prabhu Parkala, divyesh19: Remove deprecated functions and make compatible for drupal 9
#3159378 by jcnventura: License "GPL-2.0+" is a deprecated SPDX license identifier, use "GPL-2.0-or-later" instead
#2938083 by JeroenT: Remove fallbacks related code when TFA does
#2998854 by idebr, wturrell, jcnventura: Make all texts in the user interface translatable for translation extraction tools (such as Drupal.org localization)
#3125318 by codemasher, jcnventura: QR Code library update/bugfix
#3144266 by mrinalini9, damondt, jcnventura: Warning on Application Reset With No Fallbacks
#3054584 by jeroen_vreuls, bramtenhove, jcnventura, bgm: QR code can be invalid
#3152903 by jcnventura: Adjust composer.json to reflect real version requirement of otp package
#3117020 by jibran, jcnventura: Fix the requirements appearance on status report
#3001474 by Emmezali, jhedstrom, nerdstein: Cursor focus not on gacode field after putting in password for login
#3022921 by daggerhart, nerdstein, greggles, ppaliya, rahulchauhan_ec3: TOTP taking very-old verification codes
#3001751 by chipway, das.gautam27, daggerhart: Namespace Dependencies in .info.yml
#2956925 by mohit1604, Ronak.addweb: Convert array in .install file according to Drupal 8 coding standards