### PR TITLE
[GOVCMSD8-810]Update page_manager to 8.x-4.0-beta6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "drupal/minisite": "1.3",
         "drupal/modifiers": "1.4",
         "drupal/module_filter": "3.1",
-        "drupal/page_manager": "4.0-beta4",
+        "drupal/page_manager": "4.0-beta6",
         "drupal/panelizer": "4.1",
         "drupal/panels": "4.4.0",
         "drupal/paragraphs": "1.12",


### PR DESCRIPTION
## page_manager 8.x-4.0-beta6
### Release notes
Beta 6 brings in full compatibility with Drupal 9 and introduces alpha support for Layout Builder. Please report issues you find!

Items fixed since 8.x-4.0-beta5:

Issue #3132853: License "GPL-2.0+" is a deprecated SPDX license identifier
Issue #3130314: Drupal coding standards
Issue #3144917: The current_user context is no longer available, breaking Moderation Dashboard
Issue #3131106: Fix namespace of PageManagerLayoutBuilderStorage class
Issue #3109618: Fix tests on Drupal 9 and drop support for 8.7 and earlier
Issue #2960739: Create a layout builder variant
Issue #3124470: Unable to add selection criteria (content type) after updating from 8.x-4.0-beta 4 to 8.x-4.0-beta5
## page_manager 8.x-4.0-beta5
### Release notes
This release adds partial compatibility with Drupal 9 and fixes the following issues:

#3114406: Remove usage of deprecated entity.query service
#3114324: Use EntityContext and EntityContextDefinition as needed
#3109346: Formally declare compatibility with Drupal 9
#3109346: Formally declare compatibility with Drupal 9
#2960936: Convert tests to phpunit
#2859105: Update deprecated function calls
#3104652: PageManagerRoutingTest fails on Drupal 8.9
#2766931: Remove @file tag docblock from files that contain a namespaced class/interface/trait, whose file name is the class name with a .php extension