### PR TITLE
[GOVCMSD8-806] Update core to 8.9.13

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.9.11",
+        "drupal/core-recommended": "8.9.13",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "drupal/consumers": "1.11",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta5",
-        "drupal/core-recommended": "8.9.11",
+        "drupal/core-recommended": "8.9.13",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.4.0",
         "drupal/diff": "1.0",


### PR DESCRIPTION
Security Advisory - https://www.drupal.org/sa-core-2021-001
Project: Drupal core [1]
Date: 2021-January-20
Security risk: Critical 18∕25
AC:Complex/A:User/CI:All/II:All/E:Exploit/TD:Uncommon [2]
Vulnerability: Third-party libraries

Description: 
The Drupal project uses the pear Archive_Tar library, which has released a
security update that impacts Drupal.  For more information please see:

   * CVE-2020-36193 [3]

Exploits may be possible if Drupal is configured to allow .tar, .tar.gz,
.bz2, or .tlz file uploads and processes them.

Solution: 
Install the latest version:
   * If you are using Drupal 9.1, update to Drupal 9.1.3 [4].
   * If you are using Drupal 9.0, update to Drupal 9.0.11 [5].
   * If you are using Drupal 8.9, update to Drupal 8.9.13 [6].
   * If you are using Drupal 7, update to Drupal 7.78 [7].

Versions of Drupal 8 prior to 8.9.x are end-of-life and do not receive
security coverage.