### PR TITLE
[GOVCMSD8-660] Update entity_hierarchy and add a patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "drupal/entity_browser": "2.5",
         "drupal/entity_class_formatter": "1.3",
         "drupal/entity_embed": "1.1",
-        "drupal/entity_hierarchy": "2.24",
+        "drupal/entity_hierarchy": "2.25",
         "drupal/entity_reference_display": "1.3",
         "drupal/entity_reference_revisions": "1.8",
         "drupal/environment_indicator": "4.0",
@@ -156,6 +156,9 @@
              },
             "drupal/core": {
                 "Private file download returns access denied, when file attached to revision other than current - https://www.drupal.org/project/drupal/issues/1452100#comment-13653216": "https://www.drupal.org/files/issues/2020-05-29/1452100-file-access-97.patch"
+            },
+            "drupal/entity_hierarchy": {
+                "New relationships and summary field - https://www.drupal.org/files/issues/2021-03-01/3199836-23.patch": "https://www.drupal.org/files/issues/2021-03-01/3199836-23.patch"
             },
             "drupal/events_log_track": {
                 "Events Log Track breaks Entity Browser #5 - https://www.drupal.org/project/events_log_track/issues/2934036": "https://www.drupal.org/files/issues/2018-04-19/2934036-check_empty_submit-5.patch",


### PR DESCRIPTION
## entity_hierarchy 8.x-2.25
Release notes
#3188021: Re-order children incompatibility with content_moderation

### Add: New relationships and summary field patch 
