### PR TITLE
Release 1.15.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "drupal/permissions_by_term": "2.12",
         "drupal/real_aes": "2.3",
         "drupal/recaptcha": "2.4",
-        "drupal/redirect": "1.3",
+        "drupal/redirect": "1.6",
         "drupal/restui": "1.16.0",
         "drupal/robotstxt": "1.4",
         "drupal/scheduled_transitions": "2.0",

--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
         "drupal/robotstxt": "1.4",
         "drupal/scheduled_transitions": "2.0",
         "drupal/search_api": "1.16",
-        "drupal/search_api_solr": "3.9",
+        "drupal/search_api_solr": "4.1.11",
         "drupal/search_api_attachments": "1.0-beta17",
         "drupal/seckit": "2.0",
         "drupal/shield": "1.4",

--- a/composer.json
+++ b/composer.json
@@ -197,11 +197,6 @@
                   "https://www.drupal.org/files/issues/2020-10-19/tfa-2930541-22_0.patch",
                 "Users' recovery codes exposed to admin users - https://www.drupal.org/project/tfa/issues/3075304":
                   "https://www.drupal.org/files/issues/2021-01-14/tfa-3075304-15.patch"
-            },
-            "drupal/webform": {
-                "Undefined index: messages - https://www.drupal.org/project/webform/issues/3137625" :"https://www.drupal.org/files/issues/2020-05-18/3137625-3.patch",
-                "Email from name cannot be longer than 128 characters - https://www.drupal.org/project/webform/issues/3142807": "https://www.drupal.org/files/issues/2020-05-26/3142807-9.patch",
-                "Email confirmation clientside validation not working - https://www.drupal.org/project/webform/issues/3138266": "https://www.drupal.org/files/issues/2020-05-20/3138266-5.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
         "drupal/scheduled_transitions": "2.0",
         "drupal/search_api": "1.16",
         "drupal/search_api_solr": "3.9",
-        "drupal/search_api_attachments": "1.0-beta16",
+        "drupal/search_api_attachments": "1.0-beta17",
         "drupal/seckit": "2.0",
         "drupal/shield": "1.4",
         "drupal/simple_oauth": "4.5",

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "drupal/restui": "1.16.0",
         "drupal/robotstxt": "1.4",
         "drupal/scheduled_transitions": "2.0",
-        "drupal/search_api": "1.16",
+        "drupal/search_api": "1.19",
         "drupal/search_api_solr": "4.1.11",
         "drupal/search_api_attachments": "1.0-beta17",
         "drupal/seckit": "2.0",

--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
         "drupal/update_notifications_disable": "1.0",
         "drupal/username_enumeration_prevention": "1.0-beta2",
         "drupal/video_embed_field": "2.0",
-        "drupal/webform": "5.13",
+        "drupal/webform": "5.25",
         "oomphinc/composer-installers-extender": "^1.1",
         "swiftmailer/swiftmailer": "5.4.12",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",


### PR DESCRIPTION
## Modules update
* Mailsystem from 8.x-4.1 to 8.x-4.3
* Redirect from 8.x-1.3 to 8.x-1.6
* Search_API from 8.x-1.6 to 8.x-1.19
* Search_API_attachments from 8.x-1.0-beta16 to 8.x-1.0-beta17
* Search_API_Solr from 8.x-3.9 to 8.x-4.1.11
* Webform from 8.x-5.13 to 8.x-5.25

## Comments 
It addresses a recent critical security advisory issued by Drupal.org. GovCMS assessed this risk as it applied to D8 distribution. Subsequently the security risk was downgraded to moderately critical.

Deployment is scheduled on 31 March 2021 and will be conducted throughout the daytime and into the evening. No outages are expected to websites during the deployment process.

The GovCMS D8 distribution will continue to be supported after this update.

## Modules deprecated/removed
* n/a

## Important reminder for projects with configuration management enabled
Do not to import any out of date configurations of these modules. This will cause fatal errors to your websites. Once the deployment is completed you will need to export the new configurations files and commit them back to master. Deployments to all websites should be completed by 6am Thursday 1 April 2021, you can confirm this at https://status.govcms.support/.


## More information
If you have any concerns, raise a ticket at https://www.govcms.support, alternatively subscribe to https://status.govcms.support/ for information on updates to the GovCMS platform